### PR TITLE
38 user onboarding: tool to create configurable DM thread

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -10,6 +10,7 @@ Coding Conventions:
 - Strongly prefer map() and named functions over for loops. This increases readability and testability
 - Don't aggressively catch errors if you're just going to rethrow them. Prefer to handle errors once at a higher level but do ensure that stacktraces are preserved so we don't lose information.
 - In cases of unexpected external errors (eg. Slack API failure), DON'T catch errors preemptively - let the app crash so that developers will be notified and can make the appropriate fix. We don't want to pollute the codebase with unnecessary try/catch blocks. An exception is when a catch is necessary to avoid a typescript error.
+- Prefer arrow functions over named functions.
 
 Naming conventions:
 - When creating tests in Jest, don't use the word "should" in test names. For example, use "it('throws on condition X')" instead of "it('should throw on condition X')".

--- a/.cursorrules
+++ b/.cursorrules
@@ -1,6 +1,6 @@
 This is a typescript project. For prior rules specific to Python, ignore them or apply them with the appropriate modifications.
 
-Before saying you're "done" with anything, run `pnpm test && pnpm lint && pnpm typecheck` to verify, and fix any issues. Use `pnpm test` or `pnpm test [file]` for testing as you go in a tighter loop.
+Before saying you're "done" with anything, run `pnpm test && pnpm lint && pnpm typecheck` to verify, and fix any issues. Use `pnpm test` or `pnpm test [file]` for testing as you go in a tighter loop (no need to lint and typecheck as often as you test).
 For lint issues, first line of defense is `pnpm lint --fix` to fix automatically.
 
 Communication style:
@@ -47,3 +47,4 @@ Testing conventions:
 - prefer to centralize test logic - if there are several similar tests, use helper functions or declarative test cases that get mapped over with `it.each(testCases, ...)`.
 - prefer to use Jest's built-in matchers and assertions over custom logic.
 - avoid mocks when possible. Prefer to factor business logic out into pure functions that can be tested in isolation.
+- when you do need to mock a service, import & use our premade service mocks in src/services/mocks.ts where possible.

--- a/src/assistant/createNewOnboardingDmWithAdmins.test.ts
+++ b/src/assistant/createNewOnboardingDmWithAdmins.test.ts
@@ -1,0 +1,155 @@
+// Mocks must be declared before imports!
+const mockGetOnboardingConfig = jest.fn();
+const mockGetBotUserId = jest.fn();
+const mockLoggerService = {
+  logger: {
+    info: jest.fn(),
+    error: jest.fn(),
+    warn: jest.fn(),
+    debug: jest.fn(),
+  },
+};
+
+jest.mock('../services/database', () => ({
+  OfficeLocation: jest.requireActual('../services/database').OfficeLocation,
+  getOnboardingConfig: mockGetOnboardingConfig,
+}));
+jest.mock('./slackInteraction', () => ({
+  getBotUserId: mockGetBotUserId,
+}));
+jest.mock('../services/logger', () => mockLoggerService);
+
+import type { WebClient } from '@slack/web-api';
+import { OfficeLocation } from '../services/database';
+import { createNewOnboardingDmWithAdmins, getSentenceAboutAdmins } from './createNewOnboardingDmWithAdmins';
+
+describe('getSentenceAboutAdmins', () => {
+  const testCases = [
+    {
+      name: 'single admin in Seattle',
+      admins: ['U123'],
+      location: OfficeLocation.SEATTLE,
+      expected:
+        "<@U123> is also on this thread. They're the admin for 9Zero in Seattle and can help with anything you need.",
+    },
+    {
+      name: 'multiple admins in San Francisco',
+      admins: ['U123', 'U456'],
+      location: OfficeLocation.SAN_FRANCISCO,
+      expected:
+        "<@U123> and <@U456> are also on this thread. They're the admin team for 9Zero in San Francisco and can help with anything you need.",
+    },
+  ];
+
+  it.each(testCases)('returns correct sentence for $name', ({ admins, location, expected }) => {
+    const result = getSentenceAboutAdmins(admins, location);
+    expect(result).toBe(expected);
+  });
+});
+
+describe('createNewOnboardingDmWithAdmins', () => {
+  let mockClient: jest.Mocked<WebClient>;
+
+  // Default mock implementations
+  const defaultOnboardingConfig = {
+    admin_user_slack_ids: ['UADMIN'],
+    onboarding_message_content: 'Default welcome message!',
+  };
+  const defaultBotUserId = 'UBOT';
+  const defaultChannelId = 'C123';
+  const defaultUserInfo = { user: { real_name: 'Alice' } };
+
+  beforeEach(() => {
+    // Reset mocks before each test
+    jest.clearAllMocks();
+
+    // Setup default mock behaviors
+    mockGetOnboardingConfig.mockResolvedValue(defaultOnboardingConfig);
+    mockGetBotUserId.mockResolvedValue(defaultBotUserId);
+
+    mockClient = {
+      conversations: {
+        open: jest.fn().mockResolvedValue({ channel: { id: defaultChannelId } }),
+        setTopic: jest.fn(),
+      },
+      users: {
+        info: jest.fn().mockResolvedValue(defaultUserInfo),
+      },
+      chat: {
+        postMessage: jest.fn(),
+      },
+    } as unknown as jest.Mocked<WebClient>;
+  });
+
+  it('creates a DM, sets topic, and posts onboarding messages', async () => {
+    const newUserSlackId = 'UNEWUSER';
+    const location = OfficeLocation.SEATTLE;
+
+    const channelId = await createNewOnboardingDmWithAdmins(mockClient, newUserSlackId, location);
+
+    expect(mockGetOnboardingConfig).toHaveBeenCalledWith(location);
+    expect(mockGetBotUserId).toHaveBeenCalledWith(mockClient);
+    expect(mockClient.conversations.open).toHaveBeenCalledWith({ users: 'UADMIN,UBOT,UNEWUSER' });
+    expect(mockClient.conversations.setTopic).toHaveBeenCalledWith({
+      channel: defaultChannelId,
+      topic: 'Welcome Alice!',
+    });
+    // Check first welcome message
+    expect(mockClient.chat.postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: defaultChannelId,
+        text: expect.stringContaining(`Hi <@${newUserSlackId}>!`), // More specific check
+        blocks: expect.any(Array),
+      }),
+    );
+    // Check specific onboarding message
+    expect(mockClient.chat.postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: defaultChannelId,
+        text: defaultOnboardingConfig.onboarding_message_content,
+        blocks: expect.any(Array),
+      }),
+    );
+    expect(channelId).toBe(defaultChannelId);
+    expect(mockClient.chat.postMessage).toHaveBeenCalledTimes(2);
+  });
+
+  it('throws if no admin users found', async () => {
+    // Override default mock behavior for this specific test
+    mockGetOnboardingConfig.mockResolvedValue({
+      admin_user_slack_ids: [],
+      onboarding_message_content: 'irrelevant',
+    });
+
+    await expect(createNewOnboardingDmWithAdmins(mockClient, 'UNEWUSER', OfficeLocation.SEATTLE)).rejects.toThrow(
+      'No admin users found for Seattle',
+    );
+    expect(mockClient.conversations.open).not.toHaveBeenCalled();
+    expect(mockClient.chat.postMessage).not.toHaveBeenCalled();
+  });
+
+  it('posts only welcome message if onboarding_message_content is empty', async () => {
+    // Override default mock behavior
+    mockGetOnboardingConfig.mockResolvedValue({
+      admin_user_slack_ids: ['UADMIN'],
+      onboarding_message_content: '', // Empty content
+    });
+    mockClient.users.info = jest.fn().mockResolvedValue({ user: { real_name: 'Bob' } }); // Different user name
+
+    const newUserSlackId = 'UNEWUSER';
+    await createNewOnboardingDmWithAdmins(mockClient, newUserSlackId, OfficeLocation.SAN_FRANCISCO);
+
+    expect(mockClient.conversations.setTopic).toHaveBeenCalledWith({
+      channel: defaultChannelId,
+      topic: 'Welcome Bob!',
+    });
+    expect(mockClient.chat.postMessage).toHaveBeenCalledTimes(1);
+    expect(mockClient.chat.postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: defaultChannelId,
+        text: expect.stringContaining(`Hi <@${newUserSlackId}>!`), // Check welcome message
+        blocks: expect.any(Array),
+      }),
+    );
+  });
+});

--- a/src/assistant/createNewOnboardingDmWithAdmins.ts
+++ b/src/assistant/createNewOnboardingDmWithAdmins.ts
@@ -7,10 +7,7 @@ import { getBotUserId } from './slackInteraction';
 export const getSentenceAboutAdmins = (adminUserSlackIds: string[], location: OfficeLocation) => {
   const adminUserNames = adminUserSlackIds.map((id) => `<@${id}>`).join(' and ');
   const multipleAdmins = adminUserSlackIds.length > 1;
-  if (multipleAdmins) {
-    return `${adminUserNames} are also on this thread. They're the admin team for 9Zero in ${location} and can help with anything you need.`;
-  }
-  return `${adminUserNames} is also on this thread. They're the admin for 9Zero in ${location} and can help with anything you need.`;
+  return `${adminUserNames} ${multipleAdmins ? 'are' : 'is'} also on this thread. They're the admin ${multipleAdmins ? 'team ' : ''}for 9Zero in ${location} and can help with anything you need.`;
 };
 
 export async function getOfficeLocationFromSlackId(slackId: string): Promise<OfficeLocation> {

--- a/src/assistant/createNewOnboardingDmWithAdmins.ts
+++ b/src/assistant/createNewOnboardingDmWithAdmins.ts
@@ -1,0 +1,76 @@
+import type { WebClient } from '@slack/web-api';
+import type { OfficeLocation } from '../services/database';
+import { getOnboardingConfig } from '../services/database';
+import { logger } from '../services/logger';
+import { getBotUserId } from './slackInteraction';
+
+export const getSentenceAboutAdmins = (adminUserSlackIds: string[], location: OfficeLocation) => {
+  const adminUserNames = adminUserSlackIds.map((id) => `<@${id}>`).join(' and ');
+  const multipleAdmins = adminUserSlackIds.length > 1;
+  if (multipleAdmins) {
+    return `${adminUserNames} are also on this thread. They're the admin team for 9Zero in ${location} and can help with anything you need.`;
+  }
+  return `${adminUserNames} is also on this thread. They're the admin for 9Zero in ${location} and can help with anything you need.`;
+};
+
+/**
+ * Create a new onboarding thread with the admin users, the assistant, and the new user.
+ * Welcomes the new user and sends the onboarding message content.
+ */
+export async function createNewOnboardingDmWithAdmins(
+  client: WebClient,
+  newUserSlackId: string,
+  location: OfficeLocation,
+): Promise<string> {
+  const { admin_user_slack_ids, onboarding_message_content } = await getOnboardingConfig(location);
+  if (admin_user_slack_ids.length === 0) {
+    throw new Error(`No admin users found for ${location}`);
+  }
+
+  const botUserId = await getBotUserId(client);
+
+  const userIds = [...admin_user_slack_ids, botUserId, newUserSlackId];
+  logger.info(`Creating new onboarding thread with users: ${userIds}`);
+  const conversationOpenResponse = await client.conversations.open({ users: userIds.join(',') });
+  const channelId = conversationOpenResponse.channel?.id as string;
+
+  const userInfo = await client.users.info({ user: newUserSlackId });
+  const userName = userInfo.user?.real_name || userInfo.user?.name || newUserSlackId;
+  await client.conversations.setTopic({
+    channel: channelId,
+    topic: `Welcome ${userName}!`,
+  });
+
+  // Post a welcome message mentioning the new user
+  const welcomeText = `Hi <@${newUserSlackId}>! I'm Fabric, 9Zero's AI assistant for member connections.\n\nTag me anytime if you need help making connections based on interests and experience.\n\n ${getSentenceAboutAdmins(admin_user_slack_ids, location)}`;
+  await client.chat.postMessage({
+    channel: channelId,
+    text: welcomeText,
+    blocks: [
+      {
+        type: 'section',
+        text: {
+          type: 'mrkdwn',
+          text: welcomeText,
+        },
+      },
+    ],
+  });
+
+  if (onboarding_message_content) {
+    await client.chat.postMessage({
+      channel: channelId,
+      text: onboarding_message_content,
+      blocks: [
+        {
+          type: 'section',
+          text: {
+            type: 'mrkdwn',
+            text: onboarding_message_content,
+          },
+        },
+      ],
+    });
+  }
+  return channelId;
+}

--- a/src/assistant/eventHandlers/messageHandler.ts
+++ b/src/assistant/eventHandlers/messageHandler.ts
@@ -8,7 +8,7 @@ import type { SlackMessage } from '../initialLlmThread';
 import { handleIncomingMessage } from '../llmConversation';
 import { convertSlackHistoryToLLMHistory } from '../messagePacking';
 import { BASIC_ASSISTANT_DESCRIPTION } from '../prompts';
-import { fetchSlackThreadAndChannelContext, getBotUserId } from '../slackInteraction';
+import { fetchSlackThreadAndChannelContext, getBotId } from '../slackInteraction';
 
 export type ThreadMessage = MessageEvent & { thread_ts: string };
 export enum ConditionalResponse {
@@ -53,7 +53,7 @@ export const shouldRespondToMessage = async (
     channel: slackMessage.channel,
     ts: slackMessage.thread_ts,
   });
-  const botId = await getBotUserId(client);
+  const botId = await getBotId(client);
 
   if (!wePreviouslyParticipatedInThread(threadContents, botId)) {
     logger.info({ threadContents, botId }, 'We did not previously participate in this thread, skipping');

--- a/src/assistant/eventHandlers/messageHandler.ts
+++ b/src/assistant/eventHandlers/messageHandler.ts
@@ -8,7 +8,7 @@ import type { SlackMessage } from '../initialLlmThread';
 import { handleIncomingMessage } from '../llmConversation';
 import { convertSlackHistoryToLLMHistory } from '../messagePacking';
 import { BASIC_ASSISTANT_DESCRIPTION } from '../prompts';
-import { fetchSlackThreadAndChannelContext, getBotId } from '../slackInteraction';
+import { fetchSlackThreadAndChannelContext, getBotUserId } from '../slackInteraction';
 
 export type ThreadMessage = MessageEvent & { thread_ts: string };
 export enum ConditionalResponse {
@@ -53,7 +53,7 @@ export const shouldRespondToMessage = async (
     channel: slackMessage.channel,
     ts: slackMessage.thread_ts,
   });
-  const botId = await getBotId(client);
+  const botId = await getBotUserId(client);
 
   if (!wePreviouslyParticipatedInThread(threadContents, botId)) {
     logger.info({ threadContents, botId }, 'We did not previously participate in this thread, skipping');

--- a/src/assistant/llmConversation.test.ts
+++ b/src/assistant/llmConversation.test.ts
@@ -120,6 +120,7 @@ describe('llmConversation', () => {
         [],
         'C123',
         '1678886400.000001',
+        false,
       );
       expect(finalTs).toBeDefined();
     });
@@ -160,6 +161,7 @@ describe('llmConversation', () => {
         [],
         'C123',
         '1678886400.000001',
+        false,
       );
       expect(finalTs).toBeDefined();
     });
@@ -307,6 +309,7 @@ describe('runLlmConversation', () => {
       initialThread,
       'C123',
       '123.456',
+      false,
     );
 
     expect(finalTs).toBe('123.456');
@@ -369,6 +372,7 @@ describe('runLlmConversation', () => {
       initialThread,
       'C123',
       '123.456',
+      false,
     );
 
     expect(finalTs).toBe('123.456');

--- a/src/assistant/llmConversation.ts
+++ b/src/assistant/llmConversation.ts
@@ -11,7 +11,7 @@ import { type SlackMessage, buildInitialLlmThread } from './initialLlmThread';
 import { convertSlackHistoryToLLMHistory, packToolCallInfoIntoSlackMessageMetadata } from './messagePacking';
 import { addFeedbackHintReactions, fetchSlackThreadAndChannelContext } from './slackInteraction';
 import { fetchSlackThreadMessages } from './slackInteraction';
-import { getBotUserId } from './slackInteraction';
+import { getBotId } from './slackInteraction';
 import { fetchUserInfo } from './slackInteraction';
 import type { ChatMessage } from './types';
 
@@ -188,7 +188,7 @@ export const handleIncomingMessage = async ({
     }
 
     const userInfo = await fetchUserInfo(client, userId);
-    const botUserId = await getBotUserId(client);
+    const botUserId = await getBotId(client);
     const threadHistoryForLLM = convertSlackHistoryToLLMHistory(slackMessages, triggeringMessageTs);
     const initialLlmThread = buildInitialLlmThread(threadHistoryForLLM, userInfo, text, botUserId);
 

--- a/src/assistant/slackInteraction.ts
+++ b/src/assistant/slackInteraction.ts
@@ -1,4 +1,5 @@
 import type {
+  AuthTestResponse,
   ConversationsHistoryArguments,
   ConversationsRepliesArguments,
   ConversationsRepliesResponse,
@@ -136,11 +137,21 @@ export const addFeedbackHintReactions = async (client: WebClient, channel: strin
   ]);
 };
 
-export const getBotUserId = async (client: WebClient): Promise<string> => {
-  const authTest = await client.auth.test();
-  if (!authTest.ok || !authTest.bot_id) {
-    throw new Error('Could not fetch bot user ID via auth.test');
+const getAuthInfo = async (client: WebClient): Promise<AuthTestResponse> => {
+  const authTestResponse = await client.auth.test();
+  if (!authTestResponse.ok) {
+    throw new Error('Could not fetch auth info via auth.test');
   }
-  logger.info({ botUserId: authTest.bot_id }, 'Fetched bot user ID via auth.test');
-  return authTest.bot_id;
+  logger.debug({ authTestResponse }, 'Fetched auth info via auth.test');
+  return authTestResponse;
+};
+
+export const getBotId = async (client: WebClient): Promise<string> => {
+  const authTestResponse = await getAuthInfo(client);
+  return authTestResponse.bot_id as string;
+};
+
+export const getBotUserId = async (client: WebClient): Promise<string> => {
+  const authTestResponse = await getAuthInfo(client);
+  return authTestResponse.user_id as string;
 };

--- a/src/assistant/slackInteraction.ts
+++ b/src/assistant/slackInteraction.ts
@@ -150,11 +150,11 @@ const getAuthInfo = async (client: WebClient): Promise<AuthTestResponse> => {
 };
 
 export const getBotId = async (client: WebClient): Promise<string> => {
-  const authTestResponse = await getAuthInfo(client);
-  return authTestResponse.bot_id as string;
+  const authInfo = await getAuthInfo(client);
+  return authInfo.bot_id as string;
 };
 
 export const getBotUserId = async (client: WebClient): Promise<string> => {
-  const authTestResponse = await getAuthInfo(client);
-  return authTestResponse.user_id as string;
+  const authInfo = await getAuthInfo(client);
+  return authInfo.user_id as string;
 };

--- a/src/assistant/slackInteraction.ts
+++ b/src/assistant/slackInteraction.ts
@@ -19,6 +19,7 @@ export interface UserInfo {
   time_zone?: string;
   time_zone_offset?: number;
   source?: string;
+  is_admin?: boolean;
 }
 
 const sortSlackMessagesByTimestamp = (messages: MessageElement[] | undefined): MessageElement[] => {
@@ -115,6 +116,7 @@ export const fetchUserInfo = async (client: WebClient, userId: string): Promise<
   if (!userResponse.ok || !userResponse.user) {
     throw new Error(`Failed to fetch user info for ${userId}: ${userResponse.error || 'Unknown error'}`);
   }
+  logger.debug({ userResponse }, 'User info fetched');
   const user = userResponse.user;
   const userProfile = user.profile;
   return {
@@ -123,6 +125,7 @@ export const fetchUserInfo = async (client: WebClient, userId: string): Promise<
     real_name: userProfile?.real_name,
     time_zone: user.tz,
     time_zone_offset: user.tz_offset,
+    is_admin: user.is_admin,
   };
 };
 

--- a/src/migrations/20250509_02_create_onboarding_config_table.sql
+++ b/src/migrations/20250509_02_create_onboarding_config_table.sql
@@ -11,35 +11,37 @@ INSERT INTO onboarding_config (
     )
 VALUES (
         'Seattle',
-        ARRAY ['U073CUASRSR', 'U07QU1QCX52'],
         -- Lowell, Laura Knaub
-        'We' re excited to have you ! Here are some tips: -
-        Join #introductions (introduce yourself here!)
-        - Also
-        join #sea-announcements, #sea-water-cooler, and #sea-whos-in (to see who's in the space today)
-        - Make a request in #ask.
-        Outside of slack: * Bookmark the members portal
-        and members directory on your browser * Bring your lunch on Wednesdays 12 -1 for Members Lunch,
-        on Thursday for the Lunch
-        and Learn * check out other events on the [calendar](
-            https: // www.linkedin.com / feed /
-            update / urn :li :activity :7259263131774824450 /
-        ).As always let us know if there 's anything we can do to support you!'
+        ARRAY ['U073CUASRSR', 'U07QU1QCX52'],
+        'Here are some tips:
+
+1️⃣ Join #introductions (introduce yourself here!)
+2️⃣ Also join #sea-announcements, #sea-water-cooler, and #sea-whos-in (to see who''s in the space today)
+3️⃣ Make a request in #ask.
+        
+Outside of slack:
+
+  •  Bookmark the <https://members.9zero.com/login|members portal> and <https://www.notion.so/9zero/13077f10821680f38eafcce7d3f72e17|members directory> on your browser
+  •  Bring your lunch on Wednesdays 12-1 for Members Lunch and on Thursdays for the Lunch and Learn
+  •  check out other events on the <https://www.linkedin.com/feed/update/urn:li:activity:7259263131774824450/|calendar>.
+
+As always let us know if there''s anything we can do to support you!'
     ),
     (
         'San Francisco',
-        ARRAY ['U08AG6NF90T', 'U07394PGKRC'],
         -- Daphne, Kirkland
-        'We''re excited to have you! Here are some tips:
+        ARRAY ['U08AG6NF90T', 'U07394PGKRC'],
+        'Here are some tips:
+
+1️⃣ Join #introductions (introduce yourself here!)
+2️⃣ Make a request in #ask
+3️⃣ Also join #sf-events, #sf-general (for everything else), #sf-whos-in (to see who''s in the space today), #sf-coffee-chats to be randomly matched for a coffee each week... etc etc. There are so many!
         
-        - Join #introductions (introduce yourself here!)
-        - Make a request in #ask
-        - Also join #sf-events, #sf-general (for everything else), #sf-whos-in (to see who''s in the space today), #sf-coffee-chats to be randomly matched for a coffee each week... etc etc. There are so many!
-        
-        Outside of slack:
-        * Bookmark the members portal and members directory on your browser
-        * Stop by the front desk to grab your 9Zero t-shirt and get your member polaroid taken! 📸
-        * Bring your lunch on Wednesdays 12-1 for Members Lunch, and check out other events on the [calendar](https://9zero.com/sf-subscribe-to-the-events-calendar).
-        
-        As always let us know if there''s anything we can do to support you!'
+Outside of slack:
+
+  •  Bookmark the <https://members.9zero.com/login|members portal> and <https://www.notion.so/9zero/13077f10821680f38eafcce7d3f72e17|members directory> on your browser
+  •  Stop by the front desk to grab your 9Zero t-shirt and get your member polaroid taken! 📸
+  •  Bring your lunch on Wednesdays 12-1 for Members Lunch, and check out other events on the <https://9zero.com/sf-subscribe-to-the-events-calendar|calendar>.
+
+As always let us know if there''s anything we can do to support you!'
     ) ON CONFLICT (location) DO NOTHING;

--- a/src/migrations/20250509_02_create_onboarding_config_table.sql
+++ b/src/migrations/20250509_02_create_onboarding_config_table.sql
@@ -1,0 +1,45 @@
+-- Create onboarding_config table for onboarding message and admin users per location
+CREATE TABLE IF NOT EXISTS onboarding_config (
+    location TEXT PRIMARY KEY,
+    admin_user_slack_ids TEXT [] NOT NULL,
+    onboarding_message_content TEXT NOT NULL
+);
+INSERT INTO onboarding_config (
+        location,
+        admin_user_slack_ids,
+        onboarding_message_content
+    )
+VALUES (
+        'Seattle',
+        ARRAY ['U073CUASRSR', 'U07QU1QCX52'],
+        -- Lowell, Laura Knaub
+        'We' re excited to have you ! Here are some tips: -
+        Join #introductions (introduce yourself here!)
+        - Also
+        join #sea-announcements, #sea-water-cooler, and #sea-whos-in (to see who's in the space today)
+        - Make a request in #ask.
+        Outside of slack: * Bookmark the members portal
+        and members directory on your browser * Bring your lunch on Wednesdays 12 -1 for Members Lunch,
+        on Thursday for the Lunch
+        and Learn * check out other events on the [calendar](
+            https: // www.linkedin.com / feed /
+            update / urn :li :activity :7259263131774824450 /
+        ).As always let us know if there 's anything we can do to support you!'
+    ),
+    (
+        'San Francisco',
+        ARRAY ['U08AG6NF90T', 'U07394PGKRC'],
+        -- Daphne, Kirkland
+        'We''re excited to have you! Here are some tips:
+        
+        - Join #introductions (introduce yourself here!)
+        - Make a request in #ask
+        - Also join #sf-events, #sf-general (for everything else), #sf-whos-in (to see who''s in the space today), #sf-coffee-chats to be randomly matched for a coffee each week... etc etc. There are so many!
+        
+        Outside of slack:
+        * Bookmark the members portal and members directory on your browser
+        * Stop by the front desk to grab your 9Zero t-shirt and get your member polaroid taken! 📸
+        * Bring your lunch on Wednesdays 12-1 for Members Lunch, and check out other events on the [calendar](https://9zero.com/sf-subscribe-to-the-events-calendar).
+        
+        As always let us know if there''s anything we can do to support you!'
+    ) ON CONFLICT (location) DO NOTHING;

--- a/src/services/database.integration.test.ts
+++ b/src/services/database.integration.test.ts
@@ -9,6 +9,7 @@ import {
   findSimilar,
   getDocBySource,
   getLinkedInDocumentsByMemberIdentifier,
+  getOnboardingConfig,
   getOrCreateClient,
   insertOrUpdateDoc,
   updateMember,
@@ -484,7 +485,6 @@ describe('Database Integration Tests', () => {
 
     it('returns helpful warning string for non-existent member', async () => {
       const nonExistentMemberId = 'non-existent-member';
-      // Expect the function to reject with an error containing the specific message
       await expect(getLinkedInDocumentsByMemberIdentifier(nonExistentMemberId)).rejects.toThrow(
         /No synced LinkedIn profile found for the given identifier./,
       );
@@ -492,6 +492,21 @@ describe('Database Integration Tests', () => {
   });
 
   describe('getOnboardingConfig', () => {
-    // Implementation of getOnboardingConfig test case
+    it('returns onboarding config for a location', async () => {
+      const location = OfficeLocation.SEATTLE;
+      const config = await getOnboardingConfig(location);
+
+      expect(config).toEqual({
+        admin_user_slack_ids: ['U073CUASRSR', 'U07QU1QCX52'],
+        onboarding_message_content: expect.stringContaining('Join #introductions'),
+      });
+    });
+
+    it('throws error for non-existent location', async () => {
+      const nonExistentLocation = 'NonExistentLocation' as OfficeLocation;
+      await expect(getOnboardingConfig(nonExistentLocation)).rejects.toThrow(
+        'No onboarding config found for location: NonExistentLocation',
+      );
+    });
   });
 });

--- a/src/services/database.integration.test.ts
+++ b/src/services/database.integration.test.ts
@@ -483,8 +483,15 @@ describe('Database Integration Tests', () => {
     });
 
     it('returns helpful warning string for non-existent member', async () => {
-      const docs = await getLinkedInDocumentsByMemberIdentifier('NonExistentUser');
-      expect(docs).toMatch('New profiles are synced daily');
+      const nonExistentMemberId = 'non-existent-member';
+      // Expect the function to reject with an error containing the specific message
+      await expect(getLinkedInDocumentsByMemberIdentifier(nonExistentMemberId)).rejects.toThrow(
+        /No synced LinkedIn profile found for the given identifier./,
+      );
     });
+  });
+
+  describe('getOnboardingConfig', () => {
+    // Implementation of getOnboardingConfig test case
   });
 });

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -769,6 +769,20 @@ async function updateMembersFromNotion(notionMembers: NotionMemberData[]): Promi
   logger.info(`Finished updating database with Notion data. Matched: ${matchedCount}, Unmatched: ${unmatchedCount}`);
 }
 
+export interface OnboardingConfig {
+  admin_user_slack_ids: string[];
+  onboarding_message_content: string;
+}
+
+async function getOnboardingConfig(location: OfficeLocation): Promise<OnboardingConfig> {
+  const client = await getOrCreateClient();
+  const result = await client.query(
+    'SELECT admin_user_slack_ids, onboarding_message_content FROM onboarding_config WHERE location = $1',
+    [location],
+  );
+  return result.rows[0] as OnboardingConfig;
+}
+
 export {
   getOrCreateClient,
   insertOrUpdateDoc,
@@ -786,4 +800,5 @@ export {
   saveFeedback,
   upsertNotionDataForMember,
   updateMembersFromNotion,
+  getOnboardingConfig,
 };

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -786,6 +786,9 @@ async function getOnboardingConfig(location: OfficeLocation): Promise<Onboarding
     'SELECT admin_user_slack_ids, onboarding_message_content FROM onboarding_config WHERE location = $1',
     [location],
   );
+  if (result.rows.length === 0) {
+    throw new Error(`No onboarding config found for location: ${location}`);
+  }
   return result.rows[0] as OnboardingConfig;
 }
 

--- a/src/services/mocks.ts
+++ b/src/services/mocks.ts
@@ -26,6 +26,12 @@ export const mockDatabaseService = {
   getDocBySource: jest.fn(),
   deleteTypedDocumentsForMember: jest.fn(),
   insertOrUpdateDoc: jest.fn(),
+  getOnboardingConfig: jest.fn(),
+  getMemberFromSlackId: jest.fn(),
+  OfficeLocation: {
+    SEATTLE: 'Seattle',
+    SAN_FRANCISCO: 'San Francisco',
+  },
 };
 
 export const mockProxycurlService = {
@@ -36,6 +42,10 @@ export const mockSlackService = {
   getChannelId: jest.fn(),
   fetchChannelHistory: jest.fn(),
   processMessageBatch: jest.fn(),
+};
+
+export const mockSlackInteractionService = {
+  getBotUserId: jest.fn(),
 };
 
 export const mockLoggerService = {

--- a/src/services/tools.ts
+++ b/src/services/tools.ts
@@ -1,11 +1,11 @@
+import type { WebClient } from '@slack/web-api/dist/WebClient';
 import { XMLBuilder } from 'fast-xml-parser';
+import type { ChatCompletionTool } from 'openai/resources/chat';
+import { createNewOnboardingDmWithAdmins } from '../assistant/createNewOnboardingDmWithAdmins';
 import { NINEZERO_SLACK_MEMBER_LINK_PREFIX } from '../assistant/prompts';
 import { findSimilar, getLinkedInDocumentsByMemberIdentifier } from './database';
 import type { Document } from './database';
 import { generateEmbedding } from './embedding';
-import type { ChatCompletionTool } from 'openai/resources/chat';
-import { createNewOnboardingDmWithAdmins } from '../assistant/createNewOnboardingDmWithAdmins';
-import type { WebClient } from '@slack/web-api/dist/WebClient';
 import { logger } from './logger';
 
 // --- Argument Types for LLM Tool Calls ---


### PR DESCRIPTION
#38 #115 

- [x] create db table for onboarding config (maybe it should be "location config" instead??
- [x] logic to trigger an onboarding thread, with configurable info (configured through supabase interface)
- [x] new tool that Fabric can call to start a new onboarding thread
- [ ] Extend OfficeRND webhook to immediately update members in our DB when they are created/updated in ORND
- [ ] followup refactor: split `tools.ts` into multiple files, probably one for each tool
- [ ] followup refactor 2: `runLlmConversation()` has too many positional args, should probably be a kwargs object

## Manual testing

* configured local DB so that Jason and Jaime are the admins of both locations
* asked Fabric to initiate onboarding threads and saw that it worked