### PR TITLE
Fix logger.error calls to put error first, nest in "err" key as needed

### DIFF
--- a/src/assistant/ResponseManager.ts
+++ b/src/assistant/ResponseManager.ts
@@ -87,7 +87,7 @@ export default class ResponseManager {
         finalChannel = this.inProgressMessage?.channel;
       } catch (error) {
         logger.error(
-          { error, inProgressMessage: this.inProgressMessage },
+          { err: error, inProgressMessage: this.inProgressMessage },
           'Failed to update message during finalization',
         );
         // Ensure we don't return potentially stale ts/channel on error

--- a/src/assistant/eventHandlers/feedbackHandler.ts
+++ b/src/assistant/eventHandlers/feedbackHandler.ts
@@ -138,7 +138,7 @@ export const handleFeedbackShortcut = async ({
     });
     shortcutLogger.info({ triggerId, channel: channel.id, message: message.ts }, 'Feedback modal opened');
   } catch (error) {
-    shortcutLogger.error({ error, shortcut }, 'Error handling feedback shortcut');
+    shortcutLogger.error({ err: error, shortcut }, 'Error handling feedback shortcut');
   }
 };
 
@@ -243,7 +243,7 @@ export const handleFeedbackViewSubmission = async ({
     await ack();
   } catch (error) {
     viewLogger.error(
-      { error, viewId: view.id, metadata: view.private_metadata },
+      { err: error, viewId: view.id, metadata: view.private_metadata },
       'Error handling feedback view submission',
     );
     // Respond with an error update in the modal

--- a/src/assistant/eventHandlers/threadStartedHandler.ts
+++ b/src/assistant/eventHandlers/threadStartedHandler.ts
@@ -47,10 +47,10 @@ export default async function threadStartedHandler({
     }
 
     await setSuggestedPrompts({ prompts });
-  } catch (e) {
+  } catch (error) {
     logger.error(
       {
-        error: e,
+        err: error,
         event: 'thread_started',
         context: event.assistant_thread.context,
       },

--- a/src/assistant/eventHandlers/threadStartedHandler.ts
+++ b/src/assistant/eventHandlers/threadStartedHandler.ts
@@ -59,7 +59,7 @@ export default async function threadStartedHandler({
 
     await say({
       text: `Sorry, something went wrong.\n You may want to forward this error message to an admin:
-          \`\`\`\n${JSON.stringify(e, null, 2)}\n\`\`\``,
+          \`\`\`\n${JSON.stringify(error, null, 2)}\n\`\`\``,
     });
   }
 }

--- a/src/assistant/llmConversation.ts
+++ b/src/assistant/llmConversation.ts
@@ -233,6 +233,6 @@ export const handleIncomingMessage = async ({
         channel: slackChannel,
         timestamp: triggeringMessageTs,
       })
-      .catch((error: unknown) => logger.error({ err: error }, 'Failed to remove thinking_face reaction'));
+      .catch((error: unknown) => logger.error(error, 'Failed to remove thinking_face reaction'));
   }
 };

--- a/src/assistant/llmConversation.ts
+++ b/src/assistant/llmConversation.ts
@@ -233,6 +233,6 @@ export const handleIncomingMessage = async ({
         channel: slackChannel,
         timestamp: triggeringMessageTs,
       })
-      .catch((err: unknown) => logger.error({ error: err }, 'Failed to remove thinking_face reaction'));
+      .catch((error: unknown) => logger.error({ err: error }, 'Failed to remove thinking_face reaction'));
   }
 };

--- a/src/scripts/check/officernd.ts
+++ b/src/scripts/check/officernd.ts
@@ -35,7 +35,7 @@ export async function checkOfficeRnDConnection() {
       logger.warn('No members found or returned from OfficeRnD.');
     }
   } catch (error) {
-    logger.error({ err: error }, 'Error testing OfficeRnD connection');
+    logger.error(error, 'Error testing OfficeRnD connection');
     process.exitCode = 1; // Indicate failure
   }
 }

--- a/src/scripts/check/officernd.ts
+++ b/src/scripts/check/officernd.ts
@@ -35,9 +35,7 @@ export async function checkOfficeRnDConnection() {
       logger.warn('No members found or returned from OfficeRnD.');
     }
   } catch (error) {
-    // Use console.error to ensure the error object itself is logged
-    console.error('Error testing OfficeRnD connection:', error);
-    logger.error('Error testing OfficeRnD connection:', { error }); // Log via logger too
+    logger.error({ err: error }, 'Error testing OfficeRnD connection');
     process.exitCode = 1; // Indicate failure
   }
 }

--- a/src/scripts/migrate/index.ts
+++ b/src/scripts/migrate/index.ts
@@ -42,7 +42,7 @@ export async function migrate(filePath: string): Promise<void> {
   } catch (err) {
     const errorMessage =
       typeof err === 'object' && err !== null && 'message' in err ? (err as Error).message : String(err);
-    logger.error(`Migration failed: ${errorMessage}`, err);
+    logger.error({ err }, `Migration failed: ${errorMessage}`);
     process.exit(1);
   } finally {
     if (client) {

--- a/src/scripts/migrate/index.ts
+++ b/src/scripts/migrate/index.ts
@@ -39,10 +39,10 @@ export async function migrate(filePath: string): Promise<void> {
     await client.query(migrationQuery);
     logger.info(`Migration from ${path.basename(absoluteMigrationPath)} completed successfully.`);
     process.exit(0);
-  } catch (err) {
+  } catch (error) {
     const errorMessage =
-      typeof err === 'object' && err !== null && 'message' in err ? (err as Error).message : String(err);
-    logger.error({ err }, `Migration failed: ${errorMessage}`);
+      typeof error === 'object' && error !== null && 'message' in error ? (error as Error).message : String(error);
+    logger.error(error, `Migration failed: ${errorMessage}`);
     process.exit(1);
   } finally {
     if (client) {

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -80,7 +80,7 @@ async function getOrCreateClient(): Promise<Client> {
     globalClient = new Client({ connectionString: config.dbUrl });
     await globalClient.connect();
   } catch (error) {
-    logger.error('Failed to connect to database:', error);
+    logger.error(error, 'Failed to connect to database');
     throw error;
   }
 
@@ -181,7 +181,7 @@ async function insertOrUpdateDoc(doc: Document): Promise<Document> {
     returnedDoc.embedding = parseStoredEmbedding(returnedDoc.embedding as string | null);
     return returnedDoc;
   } catch (error) {
-    logger.error('Error inserting/updating document:', error);
+    logger.error(error, 'Error inserting/updating document');
     throw error;
   }
 }
@@ -203,7 +203,7 @@ async function getDocBySource(sourceUniqueId: string): Promise<Document | null> 
     doc.embedding = parseStoredEmbedding(doc.embedding as string | null);
     return doc;
   } catch (error) {
-    logger.error('Error getting document:', error);
+    logger.error(error, 'Error getting document:');
     throw error;
   }
 }
@@ -220,7 +220,7 @@ async function deleteDoc(sourceUniqueId: string): Promise<boolean> {
     const result = await client.query('DELETE FROM rag_docs WHERE source_unique_id = $1 RETURNING *', [sourceUniqueId]);
     return result.rows.length > 0;
   } catch (error) {
-    logger.error('Error deleting document:', error);
+    logger.error(error, 'Error deleting document');
     throw error;
   }
 }
@@ -319,7 +319,7 @@ async function findSimilar(embedding: number[], options: SearchOptions = {}): Pr
       },
     );
   } catch (error) {
-    logger.error(error, 'Error finding similar documents:');
+    logger.error(error, 'Error finding similar documents');
     throw error;
   }
 }
@@ -443,7 +443,7 @@ async function deleteTypedDocumentsForMember(officerndMemberId: string, typePref
     );
     logger.debug(`Deleted ${typePrefix} documents for member ${officerndMemberId}`);
   } catch (error) {
-    logger.error(`Error deleting ${typePrefix} documents for member ${officerndMemberId}:`, error);
+    logger.error(error, `Error deleting ${typePrefix} documents for member ${officerndMemberId}`);
     throw error;
   }
 }
@@ -498,7 +498,7 @@ async function getMembersWithLastLinkedInUpdates(): Promise<MemberWithLinkedInUp
     logger.info(`Fetched ${members.length} members`);
     return members;
   } catch (error) {
-    logger.error('Error getting last LinkedIn updates:', error);
+    logger.error(error, 'Error getting last LinkedIn updates');
     throw error;
   }
 }
@@ -531,7 +531,7 @@ async function getLinkedInDocuments(linkedinUrl: string): Promise<Document[]> {
       },
     }));
   } catch (error) {
-    logger.error('Error fetching LinkedIn documents by URL:', error);
+    logger.error(error, 'Error fetching LinkedIn documents by URL');
     throw error;
   }
 }
@@ -583,7 +583,7 @@ async function getLinkedInDocumentsByMemberIdentifier(
     // Map results, ensuring metadata includes view fields
     return result.rows;
   } catch (error) {
-    logger.error('Error fetching LinkedIn documents by Name:', error);
+    logger.error(error, 'Error fetching LinkedIn documents by Name');
     throw error;
   }
 }
@@ -613,7 +613,7 @@ async function saveFeedback(feedback: FeedbackVote): Promise<FeedbackVote> {
     // We assert the type here because RETURNING * should give us back the full row including DB-generated columns
     return result.rows[0] as FeedbackVote;
   } catch (error) {
-    logger.error('Error saving feedback vote:', error);
+    logger.error(error, 'Error saving feedback vote');
     throw error; // Re-throw the error to be handled by the caller
   }
 }

--- a/src/services/embedding.ts
+++ b/src/services/embedding.ts
@@ -36,13 +36,17 @@ async function generateEmbedding(text: string): Promise<number[]> {
 
     return response.data[0].embedding;
   } catch (error) {
-    logger.error('Error generating embedding:', {
-      message: error instanceof Error ? error.message : 'Unknown error',
-      status: (error as OpenAIError).status,
-      type: (error as OpenAIError).type,
-      code: (error as OpenAIError).code,
-      response: (error as OpenAIError).response?.data,
-    });
+    logger.error(
+      {
+        err: error,
+        message: error instanceof Error ? error.message : 'Unknown error',
+        status: (error as OpenAIError).status,
+        type: (error as OpenAIError).type,
+        code: (error as OpenAIError).code,
+        response: (error as OpenAIError).response?.data,
+      },
+      'Error generating embedding',
+    );
     throw error;
   }
 }
@@ -78,13 +82,17 @@ async function generateEmbeddings(texts: string[]): Promise<number[][]> {
     }
     return allEmbeddings;
   } catch (error) {
-    logger.error('Error generating embeddings:', {
-      message: error instanceof Error ? error.message : 'Unknown error',
-      status: (error as OpenAIError).status,
-      type: (error as OpenAIError).type,
-      code: (error as OpenAIError).code,
-      response: (error as OpenAIError).response?.data,
-    });
+    logger.error(
+      {
+        err: error,
+        message: error instanceof Error ? error.message : 'Unknown error',
+        status: (error as OpenAIError).status,
+        type: (error as OpenAIError).type,
+        code: (error as OpenAIError).code,
+        response: (error as OpenAIError).response?.data,
+      },
+      'Error generating embeddings',
+    );
     throw error;
   }
 }

--- a/src/services/officernd.ts
+++ b/src/services/officernd.ts
@@ -103,11 +103,14 @@ async function getAccessToken(): Promise<string> {
 
   if (!response.ok) {
     const errorText = await response.text();
-    logger.error('Token request failed:', {
-      status: response.status,
-      statusText: response.statusText,
-      body: errorText,
-    });
+    logger.error(
+      {
+        status: response.status,
+        statusText: response.statusText,
+        body: errorText,
+      },
+      'Token request failed',
+    );
     throw new Error(`Failed to get OfficeRnD access token: ${response.statusText}`);
   }
 
@@ -169,9 +172,10 @@ export const getMemberLinkedin = (member: OfficeRnDRawMemberData): string | null
   if (rawLinkedinUrl) {
     try {
       return normalizeLinkedInUrl(rawLinkedinUrl);
-    } catch (e) {
+    } catch (error) {
       logger.error(
         {
+          err: error,
           rawLinkedinUrl,
           member,
         },

--- a/src/services/proxycurl.ts
+++ b/src/services/proxycurl.ts
@@ -63,19 +63,22 @@ export async function getLinkedInProfile(linkedinUrl: string): Promise<Proxycurl
 
     if (!response.ok) {
       const errorText = await response.text();
-      logger.error('Proxycurl API error:', {
-        status: response.status,
-        statusText: response.statusText,
-        body: errorText,
-        linkedinUrl,
-      });
+      logger.error(
+        {
+          status: response.status,
+          statusText: response.statusText,
+          body: errorText,
+          linkedinUrl,
+        },
+        'Proxycurl API error',
+      );
       // Consider specific error handling based on status codes if needed
       throw new Error(`Proxycurl API error: ${response.statusText}`);
     }
 
     return (await response.json()) as ProxycurlProfile;
   } catch (error) {
-    logger.error('Error fetching LinkedIn profile:', { error, linkedinUrl });
+    logger.error({ err: error, linkedinUrl }, 'Error fetching LinkedIn profile');
     throw error; // Re-throw after logging
   }
 }

--- a/src/services/rag.ts
+++ b/src/services/rag.ts
@@ -28,7 +28,7 @@ async function retrieveRelevantDocs(query: string, options: RagOptions = {}): Pr
 
     return similarDocs;
   } catch (error) {
-    logger.error('Error in RAG retrieval:', error);
+    logger.error(error, 'Error in RAG retrieval');
     throw error;
   }
 }

--- a/src/sync/linkedin.ts
+++ b/src/sync/linkedin.ts
@@ -285,7 +285,7 @@ export async function createLinkedInDocuments(
       });
     }
   } catch (error) {
-    logger.error('Error creating LinkedIn documents:', error);
+    logger.error(error, 'Error creating LinkedIn documents');
     throw error;
   }
 }


### PR DESCRIPTION
pino does special things when logging errors. If we want to correctly log nice things like the stack trace we have to make sure to:

1. Provide either the error, or an object, as the first parameter
2. If nesting the error within an object, nest it explicitly under the **`err`** key

### Valid:
```
logger.error(error)
logger.error(error, 'message')
logger.error({ err: error }, 'message')
```

### Invalid:
```
logger.error('message', error)
logger.error({ error, otherKey: 'other'}, 'message')
```


### Examples


`logger.error(error)`
```bash
[14:27:48.776] ERROR <<anonymous>>: test
    app: "member-connections-ai"
    env: "development"
    callerLocation: "/Users/jaime/optionzero/member-connections-ai/src/app.ts:35:12"
    err: {
      "type": "Error",
      "message": "test",
      "stack":
          Error: test
              at <anonymous> (/Users/jaime/optionzero/member-connections-ai/src/app.ts:33:11)
              at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    }
```

`logger.error(error, 'with message')`
```bash
[14:27:48.777] ERROR <<anonymous>>: with message
    app: "member-connections-ai"
    env: "development"
    callerLocation: "/Users/jaime/optionzero/member-connections-ai/src/app.ts:36:12"
    err: {
      "type": "Error",
      "message": "test",
      "stack":
          Error: test
              at <anonymous> (/Users/jaime/optionzero/member-connections-ai/src/app.ts:33:11)
              at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    }
```

`logger.error({ error }, 'in object')`
```bash
[14:27:48.777] ERROR <<anonymous>>: in object
    app: "member-connections-ai"
    env: "development"
    callerLocation: "/Users/jaime/optionzero/member-connections-ai/src/app.ts:37:12"
    error: {}
```

`logger.error({ err: error, otherKey: "other value" }, 'in object using "err" key')`
```bash
[14:27:48.778] ERROR <<anonymous>>: in object using "err" key
    app: "member-connections-ai"
    env: "development"
    callerLocation: "/Users/jaime/optionzero/member-connections-ai/src/app.ts:38:12"
    otherKey: "other value"
    err: {
      "type": "Error",
      "message": "test",
      "stack":
          Error: test
              at <anonymous> (/Users/jaime/optionzero/member-connections-ai/src/app.ts:33:11)
              at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    }
```