### PR TITLE
Handle missing member.properties in officernd webhook

### DIFF
--- a/src/services/officernd.test.ts
+++ b/src/services/officernd.test.ts
@@ -225,7 +225,6 @@ describe('OfficeRnD Service', () => {
         _id: 'member-min',
         name: 'Minimal Member',
         office: '',
-        properties: {},
         calculatedStatus: 'active',
       };
 

--- a/src/services/officernd.ts
+++ b/src/services/officernd.ts
@@ -22,8 +22,8 @@ export type OfficeRnDRawMemberData = {
   name: string;
   office: string; // uuid
   linkedin?: string | null; // Undocumented property, set by member in the member portal alongside other social links
-  // Custom properies
-  properties: {
+  // Custom properies. If a member has none of these, the ORND webhook omits the "properties" attribute entirely
+  properties?: {
     // Set/controlled by integrations
     slack_id?: string;
     // Set/controlled by 9Zero admin
@@ -128,13 +128,13 @@ export const cleanMember = (member: OfficeRnDRawMemberData): OfficeRnDMemberData
   id: member._id,
   name: member.name,
   location: getOfficeLocation(member.office),
-  slackId: member.properties.slack_id || null,
+  slackId: member.properties?.slack_id || null,
   linkedinUrl: getMemberLinkedin(member),
-  sector: member.properties.Sector,
-  subsector: member.properties.Subsector,
-  blurb: member.properties.Blurb,
-  type: member.properties.Type,
-  currentRole: member.properties.CurrentRole,
+  sector: member.properties?.Sector,
+  subsector: member.properties?.Subsector,
+  blurb: member.properties?.Blurb,
+  type: member.properties?.Type,
+  currentRole: member.properties?.CurrentRole,
 });
 
 export async function getAllActiveOfficeRnDMembersData(): Promise<OfficeRnDMemberData[]> {
@@ -170,7 +170,7 @@ export async function getAllActiveOfficeRnDMembersData(): Promise<OfficeRnDMembe
 export const getMemberLinkedin = (member: OfficeRnDRawMemberData): string | null => {
   const rawLinkedinUrl =
     member.linkedin || // Prefer the member-set first-class OfficeRnD attribute
-    member.properties.LinkedInViaAdmin; // Fall back to the custom property that 9Zero staff can set
+    member.properties?.LinkedInViaAdmin; // Fall back to the custom property that 9Zero staff can set
 
   if (rawLinkedinUrl) {
     try {


### PR DESCRIPTION
Fix for this incident: https://uptime.betterstack.com/team/270156/incidents/782907058

Apparently ORND just entirely omits the `member.properties` attribute if a member has no custom properties set.

Update our code to handle that.

```
{
"dt": "2025-05-14T19:18:04.246Z", // May 14, 2025 at 12:18:04pm PDT
"level": "error",
"app": "member-connections-ai",
"env": "production",
"callerLocation": "/workspace/src/app.ts:50:12",
"caller": "<anonymous>",
"err": {
"type": "TypeError",
"message": "Cannot read properties of undefined (reading 'slack_id')",
"stack": "TypeError: Cannot read properties of undefined (reading 'slack_id') at cleanMember (/workspace/src/services/officernd.ts:131:30) at handleMemberEvent (/workspace/src/sync/officernd.ts:159:25) at handleOfficeRnDWebhook (/workspace/src/sync/officernd.ts:185:13) at <anonymous> (/workspace/src/app.ts:48:11) at Layer.handleRequest (/workspace/node_modules/.pnpm/router@2.2.0/node_modules/router/lib/layer.js:152:17) at next (/workspace/node_modules/.pnpm/router@2.2.0/node_modules/router/lib/route.js:157:13) at Route.dispatch (/workspace/node_modules/.pnpm/router@2.2.0/node_modules/router/lib/route.js:117:3) at handle (/workspace/node_modules/.pnpm/router@2.2.0/node_modules/router/index.js:435:11) at Layer.handleRequest (/workspace/node_modules/.pnpm/router@2.2.0/node_modules/router/lib/layer.js:152:17) at /workspace/node_modules/.pnpm/router@2.2.0/node_modules/router/index.js:295:15",
},
"message": "Error handling OfficeRnD webhook",
}
```