### PR TITLE
#64: member search tool

### DIFF
--- a/src/assistant/llmConversation.ts
+++ b/src/assistant/llmConversation.ts
@@ -47,10 +47,21 @@ export const runLlmConversation = async ({
     // Use thread_ts for subsequent messages in the loop to keep them threaded
     responseManager.startNewMessageWithPlaceholder('_thinking..._');
 
+    const toolSpecs = getToolSpecs(userIsAdmin);
+    logger.debug({ model: config.modelName, messages: llmThread, toolSpecs }, 'Calling for chat completion');
+    const res = await llmClient.chat.completions.create({
+      model: config.modelName,
+      messages: llmThread,
+      tools: toolSpecs,
+      tool_choice: remainingLlmLoopsAllowed === 0 ? 'none' : 'auto',
+      stream: false,
+    });
+
+    logger.debug({ res }, 'Chat completion response');
     const streamFromLlm = await llmClient.chat.completions.create({
       model: config.modelName,
       messages: llmThread,
-      tools: getToolSpecs(userIsAdmin),
+      tools: toolSpecs,
       tool_choice: remainingLlmLoopsAllowed === 0 ? 'none' : 'auto',
       stream: true,
     });

--- a/src/llmTools/LLMToolInterface.ts
+++ b/src/llmTools/LLMToolInterface.ts
@@ -8,7 +8,6 @@ export type LLMToolContext = {
 export type ToolImplementation<Params, Result> = (params: Params & { context: LLMToolContext }) => Promise<Result>;
 
 export type LLMTool<Params = unknown, Result = unknown> = {
-  toolName: string;
   specForLLM: ChatCompletionTool;
   forAdminsOnly: boolean;
   getShortDescription: (params: Params) => string;

--- a/src/llmTools/index.ts
+++ b/src/llmTools/index.ts
@@ -6,7 +6,7 @@ import type { LLMTool, LLMToolContext, ToolImplementation } from './LLMToolInter
 import { OnboardingThreadTool } from './tools/createOnboardingThreadTool';
 import { FetchLinkedInProfileTool } from './tools/fetchLinkedInProfileTool';
 import { SearchDocumentsTool } from './tools/searchDocumentsTool';
-
+import { SearchMembersTool } from './tools/searchMembersTool';
 export type LLMToolCall = {
   id: string;
   type: 'function';
@@ -17,9 +17,18 @@ export type LLMToolCall = {
 };
 
 // biome-ignore lint/suspicious/noExplicitAny: The LLMTool inputs and outputs are different for each tool
-const ALL_TOOLS: LLMTool<any, any>[] = [SearchDocumentsTool, FetchLinkedInProfileTool, OnboardingThreadTool];
+const ALL_TOOLS: LLMTool<any, any>[] = [
+  SearchMembersTool,
+  SearchDocumentsTool,
+  FetchLinkedInProfileTool,
+  OnboardingThreadTool,
+];
 
-export const TOOL_NAMES = ALL_TOOLS.map((tool) => tool.toolName) as readonly string[];
+export const getToolName = (tool: LLMTool<unknown, unknown>): string => {
+  return tool.specForLLM.function.name;
+};
+
+export const TOOL_NAMES = ALL_TOOLS.map((tool) => getToolName(tool)) as readonly string[];
 export type ToolName = (typeof TOOL_NAMES)[number];
 
 export const getToolSpecs = (userIsAdmin: boolean): ChatCompletionTool[] => {
@@ -34,7 +43,7 @@ export const getToolForToolCall = (toolCall: LLMToolCall): LLMTool<unknown, unkn
 
   const toolName = toolCall.function.name;
 
-  const tool = ALL_TOOLS.find((t) => t.toolName === toolName);
+  const tool = ALL_TOOLS.find((t) => getToolName(t) === toolName);
   if (!tool) {
     logger.error({ toolCall, toolName }, 'Unknown tool name encountered');
     throw new Error(`Unhandled tool call: ${toolName}`);
@@ -64,7 +73,7 @@ export const getToolImplementationsMap = ({
   const context: LLMToolContext = { slackClient };
 
   const toolNamesAndImplementations = ALL_TOOLS.filter((tool) => !tool.forAdminsOnly || userIsAdmin).map((tool) => {
-    return [tool.toolName, (params: object) => tool.impl({ context, ...params })];
+    return [getToolName(tool), (params: object) => tool.impl({ context, ...params })];
   });
 
   return Object.fromEntries(toolNamesAndImplementations);

--- a/src/llmTools/tools/createOnboardingThreadTool.ts
+++ b/src/llmTools/tools/createOnboardingThreadTool.ts
@@ -28,7 +28,6 @@ const createOnboardingThreadSpec: ChatCompletionTool = {
 };
 
 export const OnboardingThreadTool: LLMTool<CreateOnboardingThreadParams, CreateOnboardingThreadResult> = {
-  toolName: 'createOnboardingThread',
   forAdminsOnly: true,
   specForLLM: createOnboardingThreadSpec,
   getShortDescription: (params: CreateOnboardingThreadParams) =>

--- a/src/llmTools/tools/fetchLinkedInProfileTool.ts
+++ b/src/llmTools/tools/fetchLinkedInProfileTool.ts
@@ -35,7 +35,6 @@ const fetchLinkedInProfileSpec: ChatCompletionTool = {
 const looksLikeSlackId = (identifier: string): boolean => /^U[A-Z0-9]+$/.test(identifier);
 
 export const FetchLinkedInProfileTool: LLMTool<LinkedInProfileToolParams, LinkedInProfileToolResult> = {
-  toolName: 'fetchLinkedInProfile',
   forAdminsOnly: false,
   specForLLM: fetchLinkedInProfileSpec,
   getShortDescription: (params: LinkedInProfileToolParams) => {

--- a/src/llmTools/tools/searchDocumentsTool.ts
+++ b/src/llmTools/tools/searchDocumentsTool.ts
@@ -42,7 +42,6 @@ const searchDocumentsSpec: ChatCompletionTool = {
 };
 
 export const SearchDocumentsTool: LLMTool<SearchToolParams, SearchToolResult> = {
-  toolName: 'searchDocuments',
   forAdminsOnly: false,
   specForLLM: searchDocumentsSpec,
   getShortDescription: (params: SearchToolParams) => `Semantic search for "${params.query}"`,

--- a/src/llmTools/tools/searchMembersTool.test.ts
+++ b/src/llmTools/tools/searchMembersTool.test.ts
@@ -1,0 +1,541 @@
+import { OfficeLocation } from '../../services/database';
+import type { DocumentWithMemberContextAndSimilarity } from '../../services/database';
+import {
+  type SearchMembersToolParams,
+  coallateDocumentsByMember,
+  combineDocumentsFromMultipleQueries,
+  getShortDescription,
+} from './searchMembersTool';
+
+interface MockMemberDetails {
+  officernd_id: string;
+  name: string;
+  location: OfficeLocation;
+  slack_id: string;
+  linkedin_url: string | null;
+  checkin_location_today: OfficeLocation | null;
+  is_checked_in_today: boolean;
+}
+
+const createMockDocForCombine = (
+  params: Partial<DocumentWithMemberContextAndSimilarity & { query: string }>,
+): DocumentWithMemberContextAndSimilarity & { query: string } => {
+  const defaults: DocumentWithMemberContextAndSimilarity & { query: string } = {
+    source_type: 'slack',
+    source_unique_id: 'default_source_id',
+    content: 'default content',
+    embedding: [0.1, 0.2],
+    metadata: { original_timestamp: new Date().toISOString() },
+    // member context fields
+    member_officernd_id: 'member_default',
+    member_name: 'Default Member',
+    member_location: OfficeLocation.SEATTLE,
+    member_slack_id: 'U_DEFAULT_MEMBER',
+    member_linkedin_url: 'https://linkedin.com/in/default',
+    member_notion_page_url: null,
+    member_checkin_location_today: null,
+    member_is_checked_in_today: false,
+    // query-related fields
+    similarity: 0.5,
+    query: 'default_query',
+    ...params,
+  };
+  return defaults;
+};
+
+const createMockDocForCoallate = (
+  params: Partial<DocumentWithMemberContextAndSimilarity & { query: string }> & { memberDetails?: MockMemberDetails },
+): DocumentWithMemberContextAndSimilarity & { query: string } => {
+  const { memberDetails, ...docParams } = params;
+  const memberFields = memberDetails
+    ? {
+        member_officernd_id: memberDetails.officernd_id,
+        member_name: memberDetails.name,
+        member_location: memberDetails.location,
+        member_slack_id: memberDetails.slack_id,
+        member_linkedin_url: memberDetails.linkedin_url,
+        member_checkin_location_today: memberDetails.checkin_location_today,
+        member_is_checked_in_today: memberDetails.is_checked_in_today,
+      }
+    : {};
+
+  const defaults: DocumentWithMemberContextAndSimilarity & { query: string } = {
+    source_type: 'slack',
+    source_unique_id: 'default_source_id',
+    content: 'default content',
+    embedding: [0.1, 0.2],
+    metadata: { original_timestamp: new Date().toISOString() },
+    // member context fields
+    member_officernd_id: 'member_default',
+    member_name: 'Default Member',
+    member_location: OfficeLocation.SEATTLE,
+    member_slack_id: 'U_DEFAULT_MEMBER',
+    member_linkedin_url: 'https://linkedin.com/in/default',
+    member_notion_page_url: null,
+    member_checkin_location_today: null,
+    member_is_checked_in_today: false,
+    // query-related fields
+    similarity: 0.5,
+    query: 'default_query',
+    ...memberFields, // Apply memberDetails if provided
+    ...docParams, // Apply other specific params, potentially overriding memberDetails
+  };
+  return defaults;
+};
+
+describe('searchMembersTool', () => {
+  const HIGH_SIMILARITY = 0.9;
+  const MEDIUM_SIMILARITY = 0.8;
+  const LOW_SIMILARITY = 0.2;
+
+  describe('combineDocumentsFromMultipleQueries', () => {
+    const DOC1_ID = 'doc1';
+    const DOC2_ID = 'doc2';
+    const QUERY1 = 'query1';
+    const QUERY2 = 'query2';
+    const CONTENT_DOC1 = 'Content for doc1';
+    const CONTENT_DOC2 = 'Content for doc2';
+    const TEST_CONTENT_SINGLE_DOC = 'Test Content';
+
+    it('combines documents, sums scores, and sorts by combinedMatchScore descending', () => {
+      const doc1_q1 = createMockDocForCombine({
+        source_unique_id: DOC1_ID,
+        query: QUERY1,
+        similarity: MEDIUM_SIMILARITY,
+        content: CONTENT_DOC1,
+      });
+      const doc1_q2 = createMockDocForCombine({
+        source_unique_id: DOC1_ID,
+        query: QUERY2,
+        similarity: LOW_SIMILARITY,
+      });
+
+      const doc2_q1 = createMockDocForCombine({
+        source_unique_id: DOC2_ID,
+        query: QUERY1,
+        similarity: HIGH_SIMILARITY,
+        content: CONTENT_DOC2,
+      });
+
+      const doc3_q_other = createMockDocForCombine({
+        source_unique_id: 'doc3',
+        query: 'other_query',
+        similarity: MEDIUM_SIMILARITY + LOW_SIMILARITY + HIGH_SIMILARITY,
+        content: 'Highest score content',
+      });
+
+      const documents = [doc1_q1, doc2_q1, doc1_q2, doc3_q_other];
+      const combined = combineDocumentsFromMultipleQueries(documents);
+
+      expect(combined).toHaveLength(3);
+
+      expect(combined[0]).toEqual(
+        expect.objectContaining({
+          source_unique_id: 'doc3',
+          combinedMatchScore: expect.closeTo(1.9),
+        }),
+      );
+      expect(combined[1]).toEqual(
+        expect.objectContaining({
+          source_unique_id: DOC1_ID,
+          content: CONTENT_DOC1,
+          matchScoresByQuery: { [QUERY1]: MEDIUM_SIMILARITY, [QUERY2]: LOW_SIMILARITY },
+          combinedMatchScore: expect.closeTo(MEDIUM_SIMILARITY + LOW_SIMILARITY),
+        }),
+      );
+      expect(combined[1]?.metadata).toBeUndefined();
+
+      expect(combined[2]).toEqual(
+        expect.objectContaining({
+          source_unique_id: DOC2_ID,
+          content: CONTENT_DOC2,
+          matchScoresByQuery: { [QUERY1]: HIGH_SIMILARITY },
+          combinedMatchScore: expect.closeTo(HIGH_SIMILARITY),
+        }),
+      );
+      expect(combined[2]?.metadata).toBeUndefined();
+    });
+
+    it('handles documents with unique queries and sorts them', () => {
+      const doc1 = createMockDocForCombine({
+        source_unique_id: DOC1_ID,
+        query: QUERY1,
+        similarity: MEDIUM_SIMILARITY,
+        content: CONTENT_DOC1,
+      });
+      const doc2 = createMockDocForCombine({
+        source_unique_id: DOC2_ID,
+        query: QUERY2,
+        similarity: LOW_SIMILARITY,
+        content: CONTENT_DOC2,
+      });
+      const documents = [doc1, doc2];
+      const combined = combineDocumentsFromMultipleQueries(documents);
+
+      expect(combined).toHaveLength(2);
+      expect(combined[0]).toEqual(
+        expect.objectContaining({
+          source_unique_id: DOC1_ID,
+          content: CONTENT_DOC1,
+          matchScoresByQuery: { [QUERY1]: MEDIUM_SIMILARITY },
+          combinedMatchScore: expect.closeTo(MEDIUM_SIMILARITY),
+        }),
+      );
+      expect(combined[1]).toEqual(
+        expect.objectContaining({
+          source_unique_id: DOC2_ID,
+          content: CONTENT_DOC2,
+          matchScoresByQuery: { [QUERY2]: LOW_SIMILARITY },
+          combinedMatchScore: expect.closeTo(LOW_SIMILARITY),
+        }),
+      );
+    });
+
+    it('returns an empty array if input is empty', () => {
+      expect(combineDocumentsFromMultipleQueries([])).toEqual([]);
+    });
+
+    it('only keeps specific fields in the combined document and strips member context', () => {
+      const originalDoc = createMockDocForCombine({
+        source_type: 'linkedin',
+        source_unique_id: 'doc-fields',
+        query: QUERY1,
+        similarity: HIGH_SIMILARITY,
+        content: TEST_CONTENT_SINGLE_DOC,
+        embedding: [0.1, 0.2, 0.3],
+        metadata: { custom_field: 'custom_value', another: 123 },
+        member_name: 'Member Fields',
+        member_location: OfficeLocation.SAN_FRANCISCO,
+        member_officernd_id: 'member_xyz',
+      });
+      const documents = [originalDoc];
+      const combined = combineDocumentsFromMultipleQueries(documents);
+
+      expect(combined).toHaveLength(1);
+      const combinedDoc = combined[0];
+
+      expect(combinedDoc).toEqual(
+        expect.objectContaining({
+          source_type: 'linkedin',
+          source_unique_id: 'doc-fields',
+          content: TEST_CONTENT_SINGLE_DOC,
+          embedding: [0.1, 0.2, 0.3],
+          matchScoresByQuery: { [QUERY1]: HIGH_SIMILARITY },
+          combinedMatchScore: expect.closeTo(HIGH_SIMILARITY),
+        }),
+      );
+      expect(combinedDoc.metadata).toBeUndefined();
+      expect(combinedDoc).not.toHaveProperty('query');
+      expect(combinedDoc).not.toHaveProperty('similarity');
+      expect(combinedDoc).not.toHaveProperty('member_name');
+      expect(combinedDoc).not.toHaveProperty('member_location');
+      expect(combinedDoc).not.toHaveProperty('member_officernd_id');
+      expect(combinedDoc).not.toHaveProperty('member_slack_id');
+      expect(combinedDoc).not.toHaveProperty('member_linkedin_url');
+      expect(combinedDoc).not.toHaveProperty('member_notion_page_url');
+      expect(combinedDoc).not.toHaveProperty('member_checkin_location_today');
+      expect(combinedDoc).not.toHaveProperty('member_is_checked_in_today');
+
+      const expectedKeys = [
+        'source_type',
+        'source_unique_id',
+        'content',
+        'embedding',
+        'matchScoresByQuery',
+        'combinedMatchScore',
+      ];
+      expect(Object.keys(combinedDoc).sort()).toEqual(expectedKeys.sort());
+    });
+  });
+
+  describe('coallateDocumentsByMember', () => {
+    const MEMBER1_ID = 'member1';
+    const MEMBER1_NAME = 'Alice Wonderland';
+    const MEMBER1_SLACK_ID = 'U_ALICE';
+    const MEMBER1_LINKEDIN = 'https://linkedin.com/in/alice';
+    const MEMBER1_DETAILS: MockMemberDetails = {
+      officernd_id: MEMBER1_ID,
+      name: MEMBER1_NAME,
+      slack_id: MEMBER1_SLACK_ID,
+      linkedin_url: MEMBER1_LINKEDIN,
+      location: OfficeLocation.SEATTLE,
+      checkin_location_today: OfficeLocation.SEATTLE,
+      is_checked_in_today: true,
+    };
+
+    const MEMBER2_ID = 'member2';
+    const MEMBER2_NAME = 'Bob The Builder';
+    const MEMBER2_SLACK_ID = 'U_BOB';
+    const MEMBER2_LINKEDIN = 'https://linkedin.com/in/bob';
+    const MEMBER2_DETAILS: MockMemberDetails = {
+      officernd_id: MEMBER2_ID,
+      name: MEMBER2_NAME,
+      slack_id: MEMBER2_SLACK_ID,
+      linkedin_url: MEMBER2_LINKEDIN,
+      location: OfficeLocation.SAN_FRANCISCO,
+      checkin_location_today: null,
+      is_checked_in_today: false,
+    };
+
+    const QUERY_A = 'queryA';
+    const QUERY_B = 'queryB';
+
+    const DOC_A1_ID = 'docA1';
+    const DOC_A1_CONTENT = 'Alice doc 1 content';
+    const DOC_A2_ID = 'docA2';
+    const DOC_A2_CONTENT = 'Alice doc 2 content';
+    const DOC_B1_ID = 'docB1';
+    const DOC_B1_CONTENT = 'Bob doc 1 content';
+
+    const QUERY1 = 'query1_coallate';
+    const QUERY2 = 'query2_coallate';
+    const DOC1_ID = 'doc1_coallate';
+    const DOC2_ID = 'doc2_coallate';
+
+    const DOC1_ID_FOR_MULTI_MATCH = 'doc1_multi';
+    const DOC2_ID_FOR_MULTI_MATCH = 'doc2_multi';
+
+    const MEMBER_X_ID = 'memberX';
+    const MEMBER_X_CORRECT_NAME = 'Correct Name';
+    const MEMBER_X_CORRECT_SLACK_ID = 'U_CORRECT';
+    const MEMBER_X_INCORRECT_NAME = 'Incorrect Name Should Be Ignored';
+    const MEMBER_X_INCORRECT_SLACK_ID = 'U_INCORRECT';
+
+    const MEMBER_X_CORRECT_DETAILS: MockMemberDetails = {
+      officernd_id: MEMBER_X_ID,
+      name: MEMBER_X_CORRECT_NAME,
+      slack_id: MEMBER_X_CORRECT_SLACK_ID,
+      location: OfficeLocation.SEATTLE,
+      linkedin_url: 'https://linkedin.com/in/correctx',
+      checkin_location_today: null,
+      is_checked_in_today: false,
+    };
+
+    const MEMBER_X_INCORRECT_DETAILS: MockMemberDetails = {
+      officernd_id: MEMBER_X_ID,
+      name: MEMBER_X_INCORRECT_NAME,
+      slack_id: MEMBER_X_INCORRECT_SLACK_ID,
+      location: OfficeLocation.SAN_FRANCISCO,
+      linkedin_url: 'https://linkedin.com/in/incorrectx',
+      checkin_location_today: OfficeLocation.SEATTLE,
+      is_checked_in_today: true,
+    };
+
+    it('groups documents by member_officernd_id and formats them correctly (relevant docs sorted)', () => {
+      const docM1Q_A_high = createMockDocForCoallate({
+        memberDetails: MEMBER1_DETAILS,
+        query: QUERY_A,
+        similarity: HIGH_SIMILARITY,
+        source_unique_id: DOC_A1_ID,
+        content: DOC_A1_CONTENT,
+        embedding: [0.1],
+      });
+      const docM1Q_B_medium = createMockDocForCoallate({
+        memberDetails: MEMBER1_DETAILS,
+        query: QUERY_B,
+        similarity: MEDIUM_SIMILARITY,
+        source_unique_id: DOC_A2_ID,
+        content: DOC_A2_CONTENT,
+        embedding: [0.2],
+      });
+      const docM2Q_A_low = createMockDocForCoallate({
+        memberDetails: MEMBER2_DETAILS,
+        query: QUERY_A,
+        similarity: LOW_SIMILARITY,
+        source_unique_id: DOC_B1_ID,
+        content: DOC_B1_CONTENT,
+        embedding: [0.3],
+      });
+
+      const documents = [docM1Q_A_high, docM1Q_B_medium, docM2Q_A_low];
+      const coallated = coallateDocumentsByMember(documents);
+
+      expect(coallated).toHaveLength(2);
+
+      const memberAlice = coallated.find((m) => m.slackId === MEMBER1_SLACK_ID);
+      expect(memberAlice).toEqual(
+        expect.objectContaining({
+          name: MEMBER1_NAME,
+          location: OfficeLocation.SEATTLE,
+          slackId: MEMBER1_SLACK_ID,
+          linkedinUrl: MEMBER1_LINKEDIN,
+          checkinLocationToday: OfficeLocation.SEATTLE,
+          isCheckedInToday: true,
+          matchedQueries: expect.arrayContaining([QUERY_A, QUERY_B]),
+        }),
+      );
+      expect(memberAlice?.matchedQueries).toHaveLength(2);
+      expect(memberAlice?.relevantDocuments).toEqual([
+        expect.objectContaining({
+          source_unique_id: DOC_A1_ID,
+          content: DOC_A1_CONTENT,
+          combinedMatchScore: expect.closeTo(HIGH_SIMILARITY),
+          matchScoresByQuery: { [QUERY_A]: HIGH_SIMILARITY },
+        }),
+        expect.objectContaining({
+          source_unique_id: DOC_A2_ID,
+          content: DOC_A2_CONTENT,
+          combinedMatchScore: expect.closeTo(MEDIUM_SIMILARITY),
+          matchScoresByQuery: { [QUERY_B]: MEDIUM_SIMILARITY },
+        }),
+      ]);
+
+      const memberBob = coallated.find((m) => m.slackId === MEMBER2_SLACK_ID);
+      expect(memberBob).toEqual(
+        expect.objectContaining({
+          name: MEMBER2_NAME,
+          location: OfficeLocation.SAN_FRANCISCO,
+          slackId: MEMBER2_SLACK_ID,
+          linkedinUrl: MEMBER2_LINKEDIN,
+          matchedQueries: [QUERY_A],
+        }),
+      );
+      expect(memberBob?.relevantDocuments).toEqual([
+        expect.objectContaining({
+          source_unique_id: DOC_B1_ID,
+          content: DOC_B1_CONTENT,
+          combinedMatchScore: expect.closeTo(LOW_SIMILARITY),
+          matchScoresByQuery: { [QUERY_A]: LOW_SIMILARITY },
+        }),
+      ]);
+    });
+
+    it('handles cases where a member has multiple source documents for the same query (combined by combineDocumentsFromMultipleQueries)', () => {
+      const docM1QAd1 = createMockDocForCoallate({
+        memberDetails: MEMBER1_DETAILS,
+        query: QUERY_A,
+        similarity: HIGH_SIMILARITY,
+        source_unique_id: DOC1_ID_FOR_MULTI_MATCH,
+      });
+      const docM1QAd1_again = createMockDocForCoallate({
+        memberDetails: MEMBER1_DETAILS,
+        query: QUERY_A,
+        similarity: MEDIUM_SIMILARITY,
+        source_unique_id: DOC1_ID_FOR_MULTI_MATCH,
+      });
+      const docM1QB_d2 = createMockDocForCoallate({
+        memberDetails: MEMBER1_DETAILS,
+        query: QUERY_B,
+        similarity: LOW_SIMILARITY,
+        source_unique_id: DOC2_ID_FOR_MULTI_MATCH,
+      });
+
+      const documents = [docM1QAd1, docM1QAd1_again, docM1QB_d2];
+      const coallated = coallateDocumentsByMember(documents);
+
+      expect(coallated).toHaveLength(1);
+      const memberAlice = coallated[0];
+      expect(memberAlice).toEqual(
+        expect.objectContaining({
+          name: MEMBER1_NAME,
+          matchedQueries: expect.arrayContaining([QUERY_A, QUERY_B]),
+        }),
+      );
+      expect(memberAlice.matchedQueries).toHaveLength(2);
+
+      expect(memberAlice.relevantDocuments).toEqual([
+        expect.objectContaining({
+          source_unique_id: DOC1_ID_FOR_MULTI_MATCH,
+          matchScoresByQuery: { [QUERY_A]: expect.closeTo(HIGH_SIMILARITY + MEDIUM_SIMILARITY) },
+          combinedMatchScore: expect.closeTo(HIGH_SIMILARITY + MEDIUM_SIMILARITY),
+        }),
+        expect.objectContaining({
+          source_unique_id: DOC2_ID_FOR_MULTI_MATCH,
+          matchScoresByQuery: { [QUERY_B]: LOW_SIMILARITY },
+          combinedMatchScore: expect.closeTo(LOW_SIMILARITY),
+        }),
+      ]);
+    });
+
+    it('returns an empty array if input is empty', () => {
+      expect(coallateDocumentsByMember([])).toEqual([]);
+    });
+
+    it('correctly uses the first document for member-specific static info (name, location, etc.)', () => {
+      const doc1 = createMockDocForCoallate({
+        memberDetails: MEMBER_X_CORRECT_DETAILS,
+        query: QUERY1,
+        source_unique_id: DOC1_ID,
+      });
+      const doc2 = createMockDocForCoallate({
+        memberDetails: MEMBER_X_INCORRECT_DETAILS,
+        query: QUERY2,
+        source_unique_id: DOC2_ID,
+      });
+      const documents = [doc1, doc2];
+      const coallated = coallateDocumentsByMember(documents);
+
+      expect(coallated).toHaveLength(1);
+      const member = coallated[0];
+      expect(member).toEqual(
+        expect.objectContaining({
+          name: MEMBER_X_CORRECT_NAME,
+          location: OfficeLocation.SEATTLE,
+          slackId: MEMBER_X_CORRECT_SLACK_ID,
+          matchedQueries: expect.arrayContaining([QUERY1, QUERY2]),
+        }),
+      );
+      expect(member.matchedQueries).toHaveLength(2);
+      expect(member.relevantDocuments).toHaveLength(2);
+    });
+  });
+
+  describe('getShortDescription', () => {
+    const testCases: { name: string; params: SearchMembersToolParams; expected: string }[] = [
+      {
+        name: 'only queries (single)',
+        params: { queries: ['test query'] },
+        expected: 'Search for members associated with "test query"',
+      },
+      {
+        name: 'only queries (multiple)',
+        params: { queries: ['query1', 'query2'] },
+        expected: 'Search for members associated with "query1, query2"',
+      },
+      {
+        name: 'queries and location',
+        params: { queries: ['tech'], location: OfficeLocation.SEATTLE },
+        expected: 'Search for members in Seattle associated with "tech"',
+      },
+      {
+        name: 'queries and checkedInOnly',
+        params: { queries: ['art'], checkedInOnly: true },
+        expected: 'Search for members associated with "art" who are checked in today',
+      },
+      {
+        name: 'queries, location, and checkedInOnly',
+        params: { queries: ['finance'], location: OfficeLocation.SAN_FRANCISCO, checkedInOnly: true },
+        expected: 'Search for members in San Francisco associated with "finance" who are checked in today',
+      },
+      {
+        name: 'only location',
+        params: { queries: [], location: OfficeLocation.SEATTLE },
+        expected: 'Search for members in Seattle',
+      },
+      {
+        name: 'only checkedInOnly',
+        params: { queries: [], checkedInOnly: true },
+        expected: 'Search for members who are checked in today',
+      },
+      {
+        name: 'location and checkedInOnly',
+        params: { queries: [], location: OfficeLocation.SAN_FRANCISCO, checkedInOnly: true },
+        expected: 'Search for members in San Francisco who are checked in today',
+      },
+      {
+        name: 'no specific params (empty queries)',
+        params: { queries: [] },
+        expected: 'Search for members',
+      },
+      {
+        name: 'no specific params (undefined queries, location, checkedInOnly)',
+        params: {} as SearchMembersToolParams,
+        expected: 'Search for members',
+      },
+    ];
+
+    it.each(testCases)('returns correct description for $name', ({ params, expected }) => {
+      expect(getShortDescription(params)).toBe(expected);
+    });
+  });
+});

--- a/src/llmTools/tools/searchMembersTool.ts
+++ b/src/llmTools/tools/searchMembersTool.ts
@@ -1,0 +1,191 @@
+import type { ChatCompletionTool } from 'openai/resources/chat';
+import {
+  type Document,
+  type DocumentWithMemberContextAndSimilarity,
+  OfficeLocation,
+  findSimilar,
+} from '../../services/database';
+import { generateEmbeddings } from '../../services/embedding';
+import type { LLMTool } from '../LLMToolInterface';
+
+export interface SearchMembersToolParams {
+  queries: string[];
+  location?: string;
+  checkedInOnly?: boolean;
+  limit?: number;
+}
+
+type DocumentWithMemberContextAndQuery = DocumentWithMemberContextAndSimilarity & {
+  query: string;
+};
+
+type DocumentWithCombinedMatchedQueries = Document & {
+  combinedMatchScore: number;
+  matchScoresByQuery: Record<string, number>;
+};
+
+export type DocumentWithQuery = Document & {
+  query: string;
+};
+
+export type MemberSearchMemberResult = {
+  name: string | null;
+  slackId: string | null;
+  linkedinUrl: string | null;
+  location: OfficeLocation | null;
+  checkinLocationToday: OfficeLocation | null;
+  isCheckedInToday: boolean;
+
+  matchedQueries: string[];
+  relevantDocuments: DocumentWithCombinedMatchedQueries[];
+};
+
+export interface SearchMembersToolResult {
+  members: MemberSearchMemberResult[];
+}
+
+const DEFAULT_DOCUMENT_LIMIT_PER_QUERY = 20;
+
+const searchMembersSpec: ChatCompletionTool = {
+  type: 'function',
+  function: {
+    name: 'searchUsers',
+    description:
+      'Search for users who are associated with documents (Slack messages, LinkedIn experiences, and the members database) using semantic similarity based on the content of documents. Search results will include metadata about the member such as their office location and currently checked in location.',
+    parameters: {
+      type: 'object',
+      properties: {
+        queries: {
+          type: 'array',
+          description:
+            'An array of search queries. Users with data matching any of the queries will be included in the results, with those matching more queries being ranked higher. If looking for CTOs in agroforestry for instance, you might use ["CTO", "agroforestry"] as your queries.',
+        },
+        location: {
+          type: 'string',
+          enum: Object.values(OfficeLocation),
+          description:
+            'If provided, results will be filtered to only include users in the given 9Zero location. Recommend keeping this blank unless the user asks for results in a specific location.',
+        },
+        checkedInOnly: {
+          type: 'boolean',
+          description:
+            'If true, results will be filtered to only include users who are currently checked in. Recommend keeping this false unless the user asks for results for checked in users or "users here today".',
+        },
+        limit: {
+          type: 'number',
+          description: `Number of results to return from each query. Use ${DEFAULT_DOCUMENT_LIMIT_PER_QUERY} as a minimum and then hand-sort through the results. Since this is a "fuzzy" semantiic search, some results may be irrelevant and should be ignored.`,
+          default: DEFAULT_DOCUMENT_LIMIT_PER_QUERY,
+        },
+      },
+      required: ['queries'],
+    },
+  },
+};
+
+/* Dedup documents by source_unique_id and combine matchedQueries */
+export const combineDocumentsFromMultipleQueries = (
+  documents: DocumentWithMemberContextAndQuery[],
+): DocumentWithCombinedMatchedQueries[] => {
+  const documentsBySourceUniqueId: Record<string, DocumentWithCombinedMatchedQueries> = {};
+  for (const document of documents) {
+    const existingCombinedDoc = documentsBySourceUniqueId[document.source_unique_id];
+    const matchScoresByQuery = existingCombinedDoc?.matchScoresByQuery || {};
+    let combinedMatchScore = existingCombinedDoc?.combinedMatchScore || 0;
+
+    if (!matchScoresByQuery[document.query]) {
+      matchScoresByQuery[document.query] = 0;
+    }
+    matchScoresByQuery[document.query] += document.similarity;
+    combinedMatchScore += document.similarity;
+
+    if (!existingCombinedDoc) {
+      documentsBySourceUniqueId[document.source_unique_id] = {
+        source_type: document.source_type,
+        source_unique_id: document.source_unique_id,
+        content: document.content,
+        embedding: document.embedding,
+        matchScoresByQuery,
+        combinedMatchScore,
+      };
+    } else {
+      // Document already exists, just update scoring info
+      existingCombinedDoc.matchScoresByQuery = matchScoresByQuery;
+      existingCombinedDoc.combinedMatchScore = combinedMatchScore;
+    }
+  }
+  const combinedDocuments = Object.values(documentsBySourceUniqueId);
+  return combinedDocuments.sort((a, b) => b.combinedMatchScore - a.combinedMatchScore);
+};
+
+export const coallateDocumentsByMember = (
+  documents: DocumentWithMemberContextAndQuery[],
+): MemberSearchMemberResult[] => {
+  const documentsByMember = documents.reduce(
+    (acc, document) => {
+      if (!acc[document.member_officernd_id]) {
+        acc[document.member_officernd_id] = [];
+      }
+      acc[document.member_officernd_id].push(document);
+      return acc;
+    },
+    {} as Record<string, DocumentWithMemberContextAndQuery[]>,
+  );
+
+  const membersFormatted: MemberSearchMemberResult[] = Object.values(documentsByMember).map((documents) => {
+    const firstDocument = documents[0];
+    const matchedQueries = [...new Set(documents.map((document) => document.query))];
+    const relevantDocuments = combineDocumentsFromMultipleQueries(documents);
+    return {
+      name: firstDocument.member_name,
+      location: firstDocument.member_location,
+      slackId: firstDocument.member_slack_id,
+      linkedinUrl: firstDocument.member_linkedin_url,
+      checkinLocationToday: firstDocument.member_checkin_location_today,
+      isCheckedInToday: firstDocument.member_is_checked_in_today,
+      matchedQueries,
+      relevantDocuments,
+    };
+  });
+  return membersFormatted;
+};
+
+export const getShortDescription = (params: SearchMembersToolParams) => {
+  const locationSection = params.location ? ` in ${params.location}` : '';
+  const queriesSection = params.queries?.length > 0 ? ` associated with "${params.queries.join(', ')}"` : '';
+  const checkedInOnlySection = params.checkedInOnly ? ' who are checked in today' : '';
+  return `Search for members${locationSection}${queriesSection}${checkedInOnlySection}`;
+};
+
+export const SearchMembersTool: LLMTool<SearchMembersToolParams, SearchMembersToolResult> = {
+  forAdminsOnly: false,
+  specForLLM: searchMembersSpec,
+  getShortDescription,
+
+  impl: async ({
+    queries,
+    location,
+    checkedInOnly,
+    limit = DEFAULT_DOCUMENT_LIMIT_PER_QUERY,
+  }: SearchMembersToolParams): Promise<SearchMembersToolResult> => {
+    // Add a combined query to catch documents that match multiple queries
+    const combinedQuery = queries.join(' ');
+    const extendedQueries = [combinedQuery, ...queries];
+
+    const queriesWithEmbeddings = await generateEmbeddings(extendedQueries);
+    const documentsMatched: DocumentWithMemberContextAndQuery[] = [];
+
+    for (const [index, query] of extendedQueries.entries()) {
+      const queryEmbedding = queriesWithEmbeddings[index];
+      const documents = await findSimilar(queryEmbedding, {
+        limit,
+        memberLocation: location as OfficeLocation,
+        memberCheckedInOnly: checkedInOnly,
+        excludeEmbeddingsFromResults: true,
+      });
+      documentsMatched.push(...documents.map((document) => ({ ...document, query })));
+    }
+    return {
+      members: coallateDocumentsByMember(documentsMatched),
+    };
+  },
+};

--- a/src/services/database.integration.test.ts
+++ b/src/services/database.integration.test.ts
@@ -1,7 +1,7 @@
 import type { Client } from 'pg';
 import { mockEmbeddingsService } from './mocks';
 
-import type { DocumentWithMemberContext } from './database';
+import type { DocumentWithMemberContextAndSimilarity } from './database';
 import {
   OfficeLocation,
   bulkUpsertMembers,
@@ -473,8 +473,12 @@ describe('Database Integration Tests', () => {
       expect(docs).toHaveLength(2);
       expect(Array.isArray(docs)).toBe(true);
       expect(docs[0]).toMatchObject(memberInfo);
-      expect((docs as DocumentWithMemberContext[]).map((d) => d.source_type)).toContain('linkedin_experience');
-      expect((docs as DocumentWithMemberContext[]).map((d) => d.source_type)).toContain('linkedin_education');
+      expect((docs as DocumentWithMemberContextAndSimilarity[]).map((d) => d.source_type)).toContain(
+        'linkedin_experience',
+      );
+      expect((docs as DocumentWithMemberContextAndSimilarity[]).map((d) => d.source_type)).toContain(
+        'linkedin_education',
+      );
     });
 
     it.each([

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -16,7 +16,7 @@ export interface Document {
   updated_at?: Date;
 }
 
-export interface DocumentWithMemberContext extends Document {
+export interface DocumentWithMemberContextAndSimilarity extends Document {
   member_name: string | null;
   member_slack_id: string | null;
   member_location: OfficeLocation | null;
@@ -24,18 +24,22 @@ export interface DocumentWithMemberContext extends Document {
   member_is_checked_in_today: boolean;
   member_linkedin_url: string | null;
   member_notion_page_url: string | null;
+  member_officernd_id: string;
+  similarity: number;
 }
-
-export interface SearchOptions {
+const DEFAULT_SEARCH_LIMIT = 20;
+export type SearchOptions = {
   limit?: number;
   excludeEmbeddingsFromResults?: boolean;
-}
+  memberLocation?: OfficeLocation;
+  memberCheckedInOnly?: boolean;
+};
 
-export interface TestClient {
+export type TestClient = {
   query: jest.Mock;
   connect: jest.Mock;
   end: jest.Mock;
-}
+};
 
 export enum OfficeLocation {
   SEATTLE = 'Seattle',
@@ -233,18 +237,26 @@ async function deleteDoc(sourceUniqueId: string): Promise<boolean> {
  * @param options - Search options
  * @returns Similar documents with similarity scores and member context
  */
-async function findSimilar(embedding: number[], options: SearchOptions = {}): Promise<DocumentWithMemberContext[]> {
+async function findSimilar(
+  embedding: number[],
+  options: SearchOptions = {},
+): Promise<DocumentWithMemberContextAndSimilarity[]> {
   const client = await getOrCreateClient();
+
+  const limit = options.limit ?? DEFAULT_SEARCH_LIMIT;
+  const excludeEmbeddingsFromResults = options.excludeEmbeddingsFromResults ?? true; // Default to excluding embeddings
+  const memberLocation = options.memberLocation ?? null;
+  const filterByMemberLocation = memberLocation != null;
+  const memberCheckedInOnly = options.memberCheckedInOnly ?? false;
 
   try {
     const embeddingVector = formatForComparison(embedding);
-    const limit = options.limit || 5;
-    const excludeEmbeddingsFromResults = options.excludeEmbeddingsFromResults ?? true; // Default to excluding embeddings
 
     // Note we're not just direct querying the `rag_docs` table,
     // we're querying the view that includes member context
-    const result: QueryResult<Omit<DocumentWithMemberContext, 'member_is_checked_in_today'>> = await client.query(
-      `SELECT
+    const result: QueryResult<Omit<DocumentWithMemberContextAndSimilarity, 'member_is_checked_in_today'>> =
+      await client.query(
+        `SELECT
         source_type,
         source_unique_id,
         content,
@@ -258,12 +270,17 @@ async function findSimilar(embedding: number[], options: SearchOptions = {}): Pr
         member_checkin_location_today,
         member_linkedin_url,
         member_notion_page_url,
+        member_officernd_id,
         1 - (embedding <=> $1) as similarity
       FROM documents_with_member_context
+      WHERE
+        ${filterByMemberLocation ? 'member_location = $2 AND' : ''}
+        ${memberCheckedInOnly ? 'member_checkin_location_today IS NOT NULL AND' : ''}
+        1 = 1 -- placeholder to make the query valid when no filters applied
       ORDER BY embedding <=> $1
       LIMIT $2`,
-      [embeddingVector, limit],
-    );
+        [embeddingVector, limit ?? DEFAULT_SEARCH_LIMIT],
+      );
 
     // Enhance metadata with member context from the view
     return result.rows.map((row) => {
@@ -523,7 +540,7 @@ async function getLinkedInDocuments(linkedinUrl: string): Promise<Document[]> {
       [linkedinUrl],
     );
     // Map results, ensuring metadata includes view fields (already done by findSimilar's logic)
-    return result.rows.map((row: DocumentWithMemberContext) => ({
+    return result.rows.map((row: DocumentWithMemberContextAndSimilarity) => ({
       ...row,
       metadata: {
         ...row.metadata,
@@ -557,7 +574,9 @@ export const deleteLinkedinDocumentsForOfficerndId = async (officerndMemberId: s
  * @param memberIdentifier - The member's fullname, slackID, linkedin URL, or OfficeRnD ID
  * @returns Array of documents with their content and metadata
  */
-async function getLinkedInDocumentsByMemberIdentifier(memberIdentifier: string): Promise<DocumentWithMemberContext[]> {
+async function getLinkedInDocumentsByMemberIdentifier(
+  memberIdentifier: string,
+): Promise<DocumentWithMemberContextAndSimilarity[]> {
   const client = await getOrCreateClient();
   // Since this function call is LLM-friendly, we can't assume that the memberIdentifier is normalized if it's a linkedin URL
   const normalizedLinkedInUrl = normalizeLinkedinUrlOrNull(memberIdentifier);


### PR DESCRIPTION
New tool that looks up documents based on multiple queries, and then organizes them by member to return to the LLM.

Results appear to be substantially higher quality than the previous tool:

![image](https://github.com/user-attachments/assets/0a29846c-5784-4726-a8af-979704d6e831)


open question: should I delete the existing docs-oriented search tool?