### PR TITLE
Downgrade logger.error to warn when called immediately before throwing

### DIFF
--- a/src/assistant/ResponseManager.ts
+++ b/src/assistant/ResponseManager.ts
@@ -33,7 +33,7 @@ export default class ResponseManager {
   async startNewMessageWithPlaceholder(placeholder: string): Promise<void> {
     if (this.inProgressMessage || this.currentResponseText) {
       const msg = 'Cannot start a new message while there is an in-progress message.';
-      logger.error({
+      logger.warn({
         msg,
         inProgressMessage: this.inProgressMessage,
         currentResponseText: this.currentResponseText,

--- a/src/assistant/createNewOnboardingDmWithAdmins.ts
+++ b/src/assistant/createNewOnboardingDmWithAdmins.ts
@@ -53,7 +53,7 @@ export async function createNewOnboardingDmWithAdmins(client: WebClient, newUser
   logger.info({ conversationOpenResponse }, 'Conversation open response');
 
   if (!channel?.id) {
-    logger.error({ conversationOpenResponse }, 'Failed to create onboarding thread');
+    logger.warn({ conversationOpenResponse }, 'Failed to create onboarding thread');
     throw new Error('Failed to create onboarding thread');
   }
 

--- a/src/llmTools/index.ts
+++ b/src/llmTools/index.ts
@@ -28,7 +28,7 @@ export const getToolSpecs = (userIsAdmin: boolean): ChatCompletionTool[] => {
 
 export const getToolForToolCall = (toolCall: LLMToolCall): LLMTool<unknown, unknown> => {
   if (toolCall.type !== 'function') {
-    logger.error({ toolCall }, 'Unhandled tool call type - not a function');
+    logger.warn({ toolCall }, 'Unhandled tool call type - not a function');
     throw new Error(`Unhandled tool call type - not a function: ${toolCall.type}`);
   }
 
@@ -36,7 +36,7 @@ export const getToolForToolCall = (toolCall: LLMToolCall): LLMTool<unknown, unkn
 
   const tool = ALL_TOOLS.find((t) => t.toolName === toolName);
   if (!tool) {
-    logger.error({ toolCall, toolName }, 'Unknown tool name encountered');
+    logger.warn({ toolCall, toolName }, 'Unknown tool name encountered');
     throw new Error(`Unhandled tool call: ${toolName}`);
   }
 

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -80,7 +80,7 @@ async function getOrCreateClient(): Promise<Client> {
     globalClient = new Client({ connectionString: config.dbUrl });
     await globalClient.connect();
   } catch (error) {
-    logger.error(error, 'Failed to connect to database');
+    logger.warn(error, 'Failed to connect to database');
     throw error;
   }
 
@@ -94,7 +94,7 @@ async function checkDbConnection(): Promise<void> {
 
 async function closeDbConnection(): Promise<void> {
   if (globalClient === undefined) {
-    logger.error("Trying to close global database connection but it doesn't exist");
+    logger.warn("Trying to close global database connection but it doesn't exist");
   } else {
     await globalClient.end();
     globalClient = undefined;
@@ -181,7 +181,7 @@ async function insertOrUpdateDoc(doc: Document): Promise<Document> {
     returnedDoc.embedding = parseStoredEmbedding(returnedDoc.embedding as string | null);
     return returnedDoc;
   } catch (error) {
-    logger.error(error, 'Error inserting/updating document');
+    logger.warn(error, 'Error inserting/updating document');
     throw error;
   }
 }
@@ -203,7 +203,7 @@ async function getDocBySource(sourceUniqueId: string): Promise<Document | null> 
     doc.embedding = parseStoredEmbedding(doc.embedding as string | null);
     return doc;
   } catch (error) {
-    logger.error(error, 'Error getting document:');
+    logger.warn(error, 'Error getting document:');
     throw error;
   }
 }
@@ -220,7 +220,7 @@ async function deleteDoc(sourceUniqueId: string): Promise<boolean> {
     const result = await client.query('DELETE FROM rag_docs WHERE source_unique_id = $1 RETURNING *', [sourceUniqueId]);
     return result.rows.length > 0;
   } catch (error) {
-    logger.error(error, 'Error deleting document');
+    logger.warn(error, 'Error deleting document');
     throw error;
   }
 }
@@ -319,7 +319,7 @@ async function findSimilar(embedding: number[], options: SearchOptions = {}): Pr
       },
     );
   } catch (error) {
-    logger.error(error, 'Error finding similar documents');
+    logger.warn(error, 'Error finding similar documents');
     throw error;
   }
 }
@@ -426,7 +426,7 @@ async function bulkUpsertMembers(members: BasicMemberForUpsert[]): Promise<Membe
     logger.info(`Upserted ${members.length} members into the database.`);
     return result.rows;
   } catch (error) {
-    logger.error(error, 'Error bulk upserting members');
+    logger.warn(error, 'Error bulk upserting members');
     throw error;
   }
 }
@@ -457,7 +457,7 @@ async function deleteTypedDocumentsForMember(officerndMemberId: string, typePref
     );
     logger.debug(`Deleted ${typePrefix} documents for member ${officerndMemberId}`);
   } catch (error) {
-    logger.error(error, `Error deleting ${typePrefix} documents for member ${officerndMemberId}`);
+    logger.warn(error, `Error deleting ${typePrefix} documents for member ${officerndMemberId}`);
     throw error;
   }
 }
@@ -519,7 +519,7 @@ const getMemberOrMembersWithLastLinkedInUpdates = async (
     logger.info(`Fetched ${members.length} members`);
     return members;
   } catch (error) {
-    logger.error(error, 'Error getting last LinkedIn updates');
+    logger.warn(error, 'Error getting last LinkedIn updates');
     throw error;
   }
 };
@@ -538,7 +538,7 @@ const getMember = async (officerndId: string): Promise<Member> => {
   const result = await client.query('SELECT * FROM members WHERE officernd_id = $1', [officerndId]);
 
   if (result.rows.length !== 1) {
-    logger.error({ result, officerndId }, `Expected 1 member, got ${result.rows.length} for officerndId`);
+    logger.warn({ result, officerndId }, `Expected 1 member, got ${result.rows.length} for officerndId`);
     throw new Error(`Expected 1 member, got ${result.rows.length} for officerndId=${officerndId}`);
   }
   return result.rows[0];
@@ -572,7 +572,7 @@ async function getLinkedInDocuments(linkedinUrl: string): Promise<Document[]> {
       },
     }));
   } catch (error) {
-    logger.error(error, 'Error fetching LinkedIn documents by URL');
+    logger.warn(error, 'Error fetching LinkedIn documents by URL');
     throw error;
   }
 }
@@ -638,7 +638,7 @@ async function getLinkedInDocumentsByMemberIdentifier(memberIdentifier: string):
     // Map results, ensuring metadata includes view fields
     return result.rows;
   } catch (error) {
-    logger.error(error, 'Error fetching LinkedIn documents by Name');
+    logger.warn(error, 'Error fetching LinkedIn documents by Name');
     throw error;
   }
 }

--- a/src/services/embedding.ts
+++ b/src/services/embedding.ts
@@ -36,7 +36,7 @@ async function generateEmbedding(text: string): Promise<number[]> {
 
     return response.data[0].embedding;
   } catch (error) {
-    logger.error(
+    logger.warn(
       {
         err: error,
         message: error instanceof Error ? error.message : 'Unknown error',
@@ -82,7 +82,7 @@ async function generateEmbeddings(texts: string[]): Promise<number[][]> {
     }
     return allEmbeddings;
   } catch (error) {
-    logger.error(
+    logger.warn(
       {
         err: error,
         message: error instanceof Error ? error.message : 'Unknown error',

--- a/src/services/linkedin.ts
+++ b/src/services/linkedin.ts
@@ -14,7 +14,7 @@ export const normalizeLinkedInUrl = (linkedinUrl: string): string => {
     return `https://linkedin.com/in/${profileIdentifier}`;
   }
   // Handle cases where the URL doesn't match the expected format
-  logger.error({ linkedinUrl }, 'Invalid LinkedIn URL format');
+  logger.warn({ linkedinUrl }, 'Invalid LinkedIn URL format');
   throw new Error(`Invalid LinkedIn URL format: ${linkedinUrl} - could not extract profile identifier`);
 };
 

--- a/src/services/officernd.ts
+++ b/src/services/officernd.ts
@@ -106,7 +106,7 @@ async function getAccessToken(): Promise<string> {
 
   if (!response.ok) {
     const errorText = await response.text();
-    logger.error(
+    logger.warn(
       {
         status: response.status,
         statusText: response.statusText,

--- a/src/services/proxycurl.ts
+++ b/src/services/proxycurl.ts
@@ -43,7 +43,7 @@ export async function getLinkedInProfile(linkedinUrl: string): Promise<Proxycurl
   const apiKey = config.proxycurlApiKey;
 
   if (apiKey === null || apiKey === undefined) {
-    logger.error('Error: Proxycurl API key not configured');
+    logger.warn('Error: Proxycurl API key not configured');
     throw new Error('Proxycurl API key not configured');
   }
 
@@ -63,7 +63,7 @@ export async function getLinkedInProfile(linkedinUrl: string): Promise<Proxycurl
 
     if (!response.ok) {
       const errorText = await response.text();
-      logger.error(
+      logger.warn(
         {
           status: response.status,
           statusText: response.statusText,
@@ -78,7 +78,7 @@ export async function getLinkedInProfile(linkedinUrl: string): Promise<Proxycurl
 
     return (await response.json()) as ProxycurlProfile;
   } catch (error) {
-    logger.error({ err: error, linkedinUrl }, 'Error fetching LinkedIn profile');
+    logger.warn({ err: error, linkedinUrl }, 'Error fetching LinkedIn profile');
     throw error; // Re-throw after logging
   }
 }

--- a/src/services/rag.ts
+++ b/src/services/rag.ts
@@ -28,7 +28,7 @@ async function retrieveRelevantDocs(query: string, options: RagOptions = {}): Pr
 
     return similarDocs;
   } catch (error) {
-    logger.error(error, 'Error in RAG retrieval');
+    logger.warn(error, 'Error in RAG retrieval');
     throw error;
   }
 }

--- a/src/sync/linkedin.ts
+++ b/src/sync/linkedin.ts
@@ -314,7 +314,7 @@ export async function createLinkedInDocuments(
       });
     }
   } catch (error) {
-    logger.error(error, 'Error creating LinkedIn documents');
+    logger.warn(error, 'Error creating LinkedIn documents');
     throw error;
   }
 }

--- a/src/sync/officernd.ts
+++ b/src/sync/officernd.ts
@@ -117,7 +117,7 @@ export async function createOfficeRnDDocuments(memberData: OfficeRnDMemberData):
  */
 export const handleCheckinEvent = async (payload: OfficeRnDRawWebhookPayload) => {
   if (!['checkin.created', 'checkin.updated'].includes(payload.eventType)) {
-    logger.error({ payload }, `Unsupported event type: ${payload.eventType}`);
+    logger.warn({ payload }, `Unsupported event type: ${payload.eventType}`);
     throw new Error(`Unsupported event type: ${payload.eventType}`);
   }
 


### PR DESCRIPTION
Now that we have proactive error notifications set up with betterstack, we want to be a little less twitchy about logger.error. 

We've had a pattern of calling logger.error immediately before throwing errors, to be able to insert additional metadata. However, if we later explicitly catch the Error, then we don't want to get proactively notified about the logged error. So, in these cases, downgrade from `logger.error` to `logger.warn`

```
logger.error({ data}, <error message>)
throw new Error(<error message>)
```