### PR TITLE
Truncate message when we package it up in the context

### DIFF
--- a/src/assistant/eventHandlers/feedbackHandler.ts
+++ b/src/assistant/eventHandlers/feedbackHandler.ts
@@ -24,14 +24,12 @@ export interface FeedbackContext {
   reaction: string;
   channelId: string;
   messageTs: string;
-  originalMessageText: string;
+  truncatedMessageText: string;
 }
 
-const abbreviateAndQuoteMessage = (message: string): string => {
-  const maxLength = 300;
-  const suffix = message.length > maxLength ? ' [...]' : '';
-  const abbreviatedMessage = message.slice(0, maxLength);
-  return `> ${abbreviatedMessage.replace(/\n/g, '\n> ')}${suffix}`;
+// Replace newlines with newline + block quote character (">") so that message is rendered with quote blocks
+export const quoteMessage = (message: string): string => {
+  return `> ${message.replace(/\n/g, '\n> ')}`;
 };
 
 /**
@@ -76,7 +74,7 @@ const buildFeedbackModal = (metadata: string): View => {
         elements: [
           {
             type: 'mrkdwn',
-            text: abbreviateAndQuoteMessage(context?.originalMessageText),
+            text: quoteMessage(context?.truncatedMessageText),
           },
         ],
       },

--- a/src/assistant/eventHandlers/initiateFeedbackFlowFromReactionEvent.ts
+++ b/src/assistant/eventHandlers/initiateFeedbackFlowFromReactionEvent.ts
@@ -35,6 +35,12 @@ const getResponseIntro = (originalMessageText: string | undefined, reactionName:
   return `I see your ":${reactionName}:" reaction!`;
 };
 
+export const truncateMessage = (message: string, maxLength = 300) => {
+  const suffix = message.length > maxLength ? ' [...]' : '';
+  const truncatedMessage = message.slice(0, maxLength);
+  return `${truncatedMessage}${suffix}`;
+};
+
 /**
  * Called when a reaction is added to a message.
  * If the reaction is on a message posted by the bot, this initiates a feedback prompt.
@@ -78,12 +84,15 @@ export default async function initiateFeedbackFlowFromReactionEvent({
   });
   const originalMessageText = reactionSubjectResponse.messages?.[0]?.text;
 
-  const context = {
+  // We only include a truncated version of the original message text because the Slack API
+  // imposes a character limit per block. It's supposedly 3000 characters per block, but in practice
+  // it seems to be somewhat less
+  const context: FeedbackContext = {
     reaction: reactionName,
     channelId: event.item.channel,
     messageTs: event.item.ts,
-    originalMessageText: originalMessageText,
-  } as FeedbackContext;
+    truncatedMessageText: truncateMessage(originalMessageText || ''),
+  };
 
   const contextString = JSON.stringify(context);
 


### PR DESCRIPTION
We're getting an `invalid_blocks` error back from the Slack API when we try to respond to feedback on this thread: https://9zeromembers.slack.com/archives/C0731J4M6AK/p1747326460113709?thread_ts=1747326515.891249&cid=C0731J4M6AK

Best guess is that we're trying to post a message with a block that is over the ~3000 character limit. Add truncating to fix it.