### PR TITLE
#135 better history handling for LLM

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -46,6 +46,6 @@ Testing conventions:
 - Prefer concise, focused tests to tests that cover multiple cases.
 - Avoid having many, verbose test fixtures. Use helper functions if necessary or a centralized fixture with the spread operator to change the fixture as needed for specific cases.
 - prefer to centralize test logic - if there are several similar tests, use helper functions or declarative test cases that get mapped over with `it.each(testCases, ...)`.
-- prefer to use Jest's built-in matchers and assertions over custom logic.
+- prefer to use Jest's built-in matchers and assertions over custom logic. Use `jest.objectContaining` with `expect().toMatchObject()` to combine multiple assertions.
 - avoid mocks when possible. Prefer to factor business logic out into pure functions that can be tested in isolation.
 - when you do need to mock a service, import & use our premade service mocks in src/services/mocks.ts where possible.

--- a/src/assistant/createNewOnboardingDmWithAdmins.test.ts
+++ b/src/assistant/createNewOnboardingDmWithAdmins.test.ts
@@ -41,6 +41,7 @@ describe('createNewOnboardingDmWithAdmins', () => {
     admin_user_slack_ids: ['UADMIN'],
     onboarding_message_content: 'Default welcome message!',
   };
+  const defaultBotId = 'BBOT';
   const defaultBotUserId = 'UBOT';
   const defaultChannelId = 'C123';
   const defaultTeamId = 'T00000000';
@@ -52,7 +53,10 @@ describe('createNewOnboardingDmWithAdmins', () => {
 
     // Setup default mock behaviors
     mockDatabaseService.getOnboardingConfig.mockResolvedValue(defaultOnboardingConfig);
-    mockSlackInteractionService.getBotUserId.mockResolvedValue(defaultBotUserId);
+    mockSlackInteractionService.getBotIds.mockResolvedValue({
+      botId: defaultBotId,
+      userId: defaultBotUserId,
+    });
     mockDatabaseService.getMemberFromSlackId.mockResolvedValue({ location: OfficeLocation.SEATTLE });
 
     mockClient = {
@@ -77,7 +81,7 @@ describe('createNewOnboardingDmWithAdmins', () => {
 
     expect(mockDatabaseService.getMemberFromSlackId).toHaveBeenCalledWith(newUserSlackId);
     expect(mockDatabaseService.getOnboardingConfig).toHaveBeenCalledWith(location);
-    expect(mockSlackInteractionService.getBotUserId).toHaveBeenCalledWith(mockClient);
+    expect(mockSlackInteractionService.getBotIds).toHaveBeenCalledWith(mockClient);
     expect(mockClient.conversations.open).toHaveBeenCalledWith({ users: 'UADMIN,UBOT,UNEWUSER' });
     expect(mockClient.conversations.setTopic).toHaveBeenCalledWith({
       channel: defaultChannelId,

--- a/src/assistant/createNewOnboardingDmWithAdmins.ts
+++ b/src/assistant/createNewOnboardingDmWithAdmins.ts
@@ -3,7 +3,7 @@ import type { Channel } from '@slack/web-api/dist/types/response/ConversationsOp
 import type { OfficeLocation } from '../services/database';
 import { getMemberFromSlackId, getOnboardingConfig } from '../services/database';
 import { logger } from '../services/logger';
-import { getBotUserId } from './slackInteraction';
+import { getBotIds } from './slackInteraction';
 
 export const getSentenceAboutAdmins = (adminUserSlackIds: string[], location: OfficeLocation) => {
   const adminUserNames = adminUserSlackIds.map((id) => `<@${id}>`).join(' and ');
@@ -41,7 +41,7 @@ export async function createNewOnboardingDmWithAdmins(client: WebClient, newUser
     throw new Error(`No admin users found for ${location}`);
   }
 
-  const botUserId = await getBotUserId(client);
+  const { userId: botUserId } = await getBotIds(client);
 
   const userIds = [...admin_user_slack_ids, botUserId, newUserSlackId];
   logger.info(`Creating new onboarding thread with users: ${userIds}`);

--- a/src/assistant/eventHandlers/messageHandler.ts
+++ b/src/assistant/eventHandlers/messageHandler.ts
@@ -6,7 +6,7 @@ import { config } from '../../config';
 import { logger } from '../../services/logger';
 import type { SlackMessage } from '../initialLlmThread';
 import { handleIncomingMessage } from '../llmConversation';
-import { convertSlackHistoryToLLMHistory } from '../messagePacking';
+import { convertSlackHistoryForLLMContext } from '../messagePacking';
 import { BASIC_ASSISTANT_DESCRIPTION } from '../prompts';
 import { fetchSlackThreadAndChannelContext, getBotUserId } from '../slackInteraction';
 
@@ -110,7 +110,7 @@ export const isDirectedAtUs = async (
   if (!threadMessages) {
     throw new Error(`No messages in thread for message ts ${slackMessage.ts}`);
   }
-  const llmHistory = convertSlackHistoryToLLMHistory(threadMessages, slackMessage.ts);
+  const llmHistory = convertSlackHistoryForLLMContext(threadMessages, slackMessage.ts);
   const messagesForLlm = [
     {
       role: 'system',

--- a/src/assistant/initialLlmThread.ts
+++ b/src/assistant/initialLlmThread.ts
@@ -20,10 +20,10 @@ export interface SlackMessage {
 }
 
 /**
- * Builds the initial message list for the LLM, including system prompts, history, and the current user message.
+ * Builds the initial message list for the LLM, including system prompts, history summary, and the current user message.
  */
 export const buildInitialLlmThread = (
-  history: ChatMessage[],
+  conversationSummary: string,
   userInfo: UserInfo,
   userMessageText: string,
   botUserId: string,
@@ -34,16 +34,18 @@ export const buildInitialLlmThread = (
     { role: 'system', content: DEFAULT_SYSTEM_CONTENT },
     {
       role: 'system',
-      content: `The current date and time is ${new Date().toISOString()} and your slack ID is ${botUserId}.`,
+      content: `The current date and time is ${new Date().toISOString()}. Your Slack user ID is <@${botUserId}>.`,
     },
-    { role: 'system', content: 'Here is the conversation history (if any):' },
-    ...history,
     {
       role: 'system',
-      content: `The following message is from: ${JSON.stringify(userInfo)}`,
+      content: `Summary of the immediately preceding conversation (users are referred to by their Slack IDs):\n${conversationSummary}\n`,
+    },
+    {
+      role: 'system',
+      content: `The current task is to respond to the most recent user message, in the context of the immediately preceding conversation. The user who left the last message is (details): ${JSON.stringify(userInfo)}. Their most recent message follows.`,
     },
     userMessage,
   ];
-  logger.debug({ threadLength: llmThread.length, thread: llmThread }, 'LLM thread prepared');
+  logger.debug({ threadLength: llmThread.length, llmThread }, 'LLM thread prepared');
   return llmThread;
 };

--- a/src/assistant/initialLlmThread.ts
+++ b/src/assistant/initialLlmThread.ts
@@ -2,7 +2,7 @@ import type { ChatCompletionUserMessageParam } from 'openai/resources/chat';
 import type { ChatCompletionMessageToolCall } from 'openai/resources/chat';
 import { logger } from '../services/logger';
 import { DEFAULT_SYSTEM_CONTENT } from './prompts';
-import type { UserInfo } from './slackInteraction';
+import type { BotIds, UserInfo } from './slackInteraction';
 import type { ChatMessage } from './types';
 
 export interface SlackMessage {
@@ -23,10 +23,10 @@ export interface SlackMessage {
  * Builds the initial message list for the LLM, including system prompts, history summary, and the current user message.
  */
 export const buildInitialLlmThread = (
-  conversationSummary: string,
+  conversationSummary: ChatMessage[],
   userInfo: UserInfo,
   userMessageText: string,
-  botUserId: string,
+  botIds: BotIds,
 ): ChatMessage[] => {
   const userMessage: ChatCompletionUserMessageParam = { role: 'user', content: userMessageText };
 
@@ -34,15 +34,12 @@ export const buildInitialLlmThread = (
     { role: 'system', content: DEFAULT_SYSTEM_CONTENT },
     {
       role: 'system',
-      content: `The current date and time is ${new Date().toISOString()}. Your Slack user ID is <@${botUserId}>.`,
+      content: `The current date and time is ${new Date().toISOString()}. Your Slack bot ID is <@${botIds.botId}> and your Slack user ID is <@${botIds.userId}>.`,
     },
+    ...conversationSummary,
     {
       role: 'system',
-      content: `Summary of the immediately preceding conversation (users are referred to by their Slack IDs):\n${conversationSummary}\n`,
-    },
-    {
-      role: 'system',
-      content: `The current task is to respond to the most recent user message, in the context of the immediately preceding conversation. The user who left the last message is (details): ${JSON.stringify(userInfo)}. Their most recent message follows.`,
+      content: `The current task is to respond to the most recent user message, in the context of the immediately preceding conversation. Details of the user who left the last message: ${JSON.stringify(userInfo)}. Their most recent message follows.`,
     },
     userMessage,
   ];

--- a/src/assistant/llmConversation.ts
+++ b/src/assistant/llmConversation.ts
@@ -1,6 +1,5 @@
 import type { SayFn } from '@slack/bolt';
 import type { WebClient } from '@slack/web-api';
-import type { MessageElement } from '@slack/web-api/dist/types/response/ConversationsHistoryResponse';
 import type { OpenAI } from 'openai';
 import { config } from '../config';
 import { type LLMToolCall, getToolCallShortDescription, getToolImplementationsMap, getToolSpecs } from '../llmTools';
@@ -196,7 +195,7 @@ export const handleIncomingMessage = async ({
         ? await fetchSlackThreadAndChannelContext(client, slackChannel, thread_ts || triggeringMessageTs)
         : await fetchSlackThreadMessages(client, slackChannel, thread_ts);
 
-    const slackMessagesForHistory: MessageElement[] = (rawSlackMessages || []) as MessageElement[];
+    const slackMessagesForHistory = rawSlackMessages || [];
     logger.debug({ slackMessagesCount: slackMessagesForHistory.length }, 'Slack messages for history fetched');
 
     if (!userId) {

--- a/src/assistant/messagePacking.test.ts
+++ b/src/assistant/messagePacking.test.ts
@@ -1,102 +1,8 @@
 import type { MessageElement } from '@slack/web-api/dist/types/response/ConversationsHistoryResponse';
 import type { ChatCompletionMessageToolCall } from 'openai/resources/chat/completions';
-import {
-  convertSlackHistoryToLLMHistory,
-  getPlaceholderToolCallResponses,
-  packToolCallInfoIntoSlackMessageMetadata,
-  unpackToolCallSlackMessage,
-} from './messagePacking';
+import { convertSlackHistoryForLLMContext, packToolCallInfoIntoSlackMessageMetadata } from './messagePacking';
 
 describe('messagePacking', () => {
-  describe('getPlaceholderToolCallResponses', () => {
-    it('should create placeholder responses for tool calls', () => {
-      const toolCalls: ChatCompletionMessageToolCall[] = [
-        {
-          id: 'call1',
-          type: 'function',
-          function: {
-            name: 'test_function',
-            arguments: '{}',
-          },
-        },
-        {
-          id: 'call2',
-          type: 'function',
-          function: {
-            name: 'another_function',
-            arguments: '{"foo": "bar"}',
-          },
-        },
-      ];
-
-      const result = getPlaceholderToolCallResponses(toolCalls);
-      expect(result).toHaveLength(2);
-      expect(result[0]).toEqual({
-        role: 'tool',
-        tool_call_id: 'call1',
-        content:
-          '<This data has been removed as it was not stored in memory. You may repeat the tool call request to refetch the data.>',
-      });
-      expect(result[1]).toEqual({
-        role: 'tool',
-        tool_call_id: 'call2',
-        content:
-          '<This data has been removed as it was not stored in memory. You may repeat the tool call request to refetch the data.>',
-      });
-    });
-
-    it('should handle empty tool calls array', () => {
-      const result = getPlaceholderToolCallResponses([]);
-      expect(result).toEqual([]);
-    });
-  });
-
-  describe('unpackToolCallSlackMessage', () => {
-    it('should unpack tool calls from message metadata', () => {
-      const toolCalls: ChatCompletionMessageToolCall[] = [
-        {
-          id: 'call1',
-          type: 'function',
-          function: {
-            name: 'test_function',
-            arguments: '{}',
-          },
-        },
-      ];
-
-      const slackMessage: MessageElement = {
-        type: 'message',
-        text: 'Test message',
-        metadata: {
-          event_type: 'llm_tool_calls',
-          event_payload: {
-            tool_calls: JSON.stringify(toolCalls),
-          },
-        },
-      };
-
-      const result = unpackToolCallSlackMessage(slackMessage);
-      expect(result).toHaveLength(2); // Assistant message + tool response
-      const assistantMessage = result[0];
-      if (assistantMessage.role !== 'assistant') {
-        throw new Error('Expected assistant message');
-      }
-      expect(assistantMessage.role).toBe('assistant');
-      expect(assistantMessage.tool_calls).toHaveLength(1);
-      expect(result[1].role).toBe('tool');
-    });
-
-    it('should return empty array for messages without tool call metadata', () => {
-      const slackMessage: MessageElement = {
-        type: 'message',
-        text: 'Test message',
-      };
-
-      const result = unpackToolCallSlackMessage(slackMessage);
-      expect(result).toEqual([]);
-    });
-  });
-
   describe('packToolCallInfoIntoSlackMessageMetadata', () => {
     it('should pack tool calls into message metadata', () => {
       const toolCalls: ChatCompletionMessageToolCall[] = [
@@ -145,10 +51,12 @@ describe('messagePacking', () => {
         },
       ];
 
-      const result = convertSlackHistoryToLLMHistory(slackHistory, '1234.5680');
-      expect(result).toHaveLength(2);
-      expect(result[0]).toEqual({ role: 'user', content: '<@U123>: User message 1' });
-      expect(result[1]).toEqual({ role: 'assistant', content: 'Bot message' });
+      const result = convertSlackHistoryForLLMContext(slackHistory, 'B123');
+      expect(result).toHaveLength(1); // Now returns a single system message
+      expect(result[0].role).toBe('system');
+      expect(result[0].content).toContain('User <@U123>: User message 1');
+      expect(result[0].content).toContain('Assistant: Bot message');
+      expect(result[0].content).toContain('User <@U123>: User message 2');
     });
 
     it('should handle messages with tool calls', () => {
@@ -178,22 +86,11 @@ describe('messagePacking', () => {
         },
       ];
 
-      const result = convertSlackHistoryToLLMHistory(slackHistory, '1234.5680');
-      expect(result).toHaveLength(3); // Bot message + assistant tool calls + tool response
-      expect(result[0]).toEqual({ role: 'assistant', content: 'Bot message with tool calls' });
-
-      const assistantToolCallMessage = result[1];
-      if (assistantToolCallMessage.role !== 'assistant') {
-        throw new Error('Expected assistant message with tool calls');
-      }
-      expect(assistantToolCallMessage.role).toBe('assistant');
-      expect(assistantToolCallMessage.tool_calls).toBeDefined();
-
-      const toolResponseMessage = result[2];
-      if (toolResponseMessage.role !== 'tool') {
-        throw new Error('Expected tool response message');
-      }
-      expect(toolResponseMessage.role).toBe('tool');
+      const result = convertSlackHistoryForLLMContext(slackHistory, 'B123');
+      expect(result).toHaveLength(1); // Now returns a single system message
+      expect(result[0].role).toBe('system');
+      expect(result[0].content).toContain('Assistant used tool(s):');
+      expect(result[0].content).toContain('test_function');
     });
 
     it('should skip messages with undefined text', () => {
@@ -211,9 +108,13 @@ describe('messagePacking', () => {
         },
       ];
 
-      const result = convertSlackHistoryToLLMHistory(slackHistory, '1234.5680');
+      const result = convertSlackHistoryForLLMContext(slackHistory, 'B123');
       expect(result).toHaveLength(1);
-      expect(result[0].content).toBe('<@U123>: Valid message');
+      expect(result[0].role).toBe('system');
+      expect(result[0].content).toContain('User <@U123>: Valid message');
+      // Check that it doesn't include anything for the message with no text
+      expect(result[0].content).not.toContain('undefined');
+      expect(result[0].content).not.toContain('null');
     });
   });
 });

--- a/src/assistant/messagePacking.ts
+++ b/src/assistant/messagePacking.ts
@@ -59,14 +59,14 @@ export const stringifySlackMessage = (message: MessageElement, botUserId: string
 /**
  * Convert Slack message history into a human- and LLM-readable
  */
-export function stringifySlackConversation(messages: MessageElement[], botUserId: string): string {
-  const conversationLines = messages.map((message) => stringifySlackMessage(message, botUserId));
+export function stringifySlackConversation(messages: MessageElement[], botId: string): string {
+  const conversationLines = messages.map((message) => stringifySlackMessage(message, botId));
 
   return conversationLines ? conversationLines.join('\n') : NO_CONVERSATION_HISTORY_SUMMARY;
 }
 
-export const convertSlackHistoryForLLMContext = (messages: MessageElement[], botUserId: string): ChatMessage[] => {
-  const conversationString = stringifySlackConversation(messages, botUserId);
+export const convertSlackHistoryForLLMContext = (messages: MessageElement[], botId: string): ChatMessage[] => {
+  const conversationString = stringifySlackConversation(messages, botId);
   return [
     {
       role: 'system',

--- a/src/assistant/messagePacking.ts
+++ b/src/assistant/messagePacking.ts
@@ -4,10 +4,11 @@ import type { MessageMetadata } from '@slack/web-api/dist';
 import type { FluffyMetadata, MessageElement } from '@slack/web-api/dist/types/response/ConversationsHistoryResponse';
 import type { ChatCompletionMessageToolCall } from 'openai/resources/chat/completions';
 import type { ChatMessage } from './types';
+// Consider adding: import { logger } from '../services/logger';
 
 type MessageMetadataWithToolCalls = MessageMetadata & {
   event_payload: {
-    tool_calls: string;
+    tool_calls: string; // This is JSON.stringified ChatCompletionMessageToolCall[]
   };
   event_type: 'llm_tool_calls';
 };
@@ -17,52 +18,53 @@ function isMessageMetadataWithToolCalls(
   return metadata?.event_type === 'llm_tool_calls';
 }
 
-/**
- * Unpack tool call info from a Slack message metadata, if present.
- * this allows us to construct an LLM chat history that includes tool calls that were previously made by the assistant.
- * Without this, the LLM sees a chat thread where it has knowledge without having to make tool calls, and starts hallucinating.
- *
- * @param slackMessage - The Slack message to unpack.
- * @returns LLM chat messages containing the tool call info, or an empty array if no tool call info is present.
- */
-export const unpackToolCallSlackMessage = (slackMessage: MessageElement): ChatMessage[] => {
-  const metadata = slackMessage.metadata;
-  if (isMessageMetadataWithToolCalls(metadata)) {
-    const toolCallsPacked = metadata?.event_payload?.tool_calls;
-    const toolCallsUnpacked = JSON.parse(toolCallsPacked) as ChatCompletionMessageToolCall[];
-    return [
-      // This message simulates when the assistant made the tool calls
-      {
-        role: 'assistant',
-        content: null,
-        tool_calls: toolCallsUnpacked,
-      },
-      // This message simulates when the tool calls were completed and sent back to the assistant
-      ...getPlaceholderToolCallResponses(toolCallsUnpacked),
-    ];
+const getCompleteToolCallInfoFromMessage = (message: MessageElement): string | undefined => {
+  if (isMessageMetadataWithToolCalls(message.metadata)) {
+    return message.metadata.event_payload.tool_calls;
   }
-  return [];
+  return undefined;
 };
 
 /**
- * Provided placeholder tool call responses that the assistant expects to see in the chat history after a tool call is made.
- * Since we don't have the actual tool call responses, we include an apologetic message instead.
- *
- * @param toolCalls - The tool calls to create placeholder messages for.
- * @returns A list of tool call messages with placeholder content.
+ * Creates a human-and LLM-readable summary of the conversation from Slack messages.
+ * @param messages - Array of Slack messages (MessageElement).
+ * @param botUserId - The Slack ID of the bot, to identify assistant messages.
+ * @returns A string summarizing the conversation.
  */
-export const getPlaceholderToolCallResponses = (toolCalls: ChatCompletionMessageToolCall[]): ChatMessage[] => {
-  return toolCalls.map((toolCall) => ({
-    role: 'tool',
-    tool_call_id: `${toolCall.id}`,
-    content:
-      '<This data has been removed as it was not stored in memory. You may repeat the tool call request to refetch the data.>',
-  }));
+export const createConversationSummary = (messages: MessageElement[], botUserId?: string): string => {
+  if (!messages || messages.length === 0) {
+    return 'No prior conversation history.';
+  }
+
+  const summaryLines: string[] = [];
+
+  for (const message of messages) {
+    const trimmedMessageText = message.text?.trim();
+    if (!trimmedMessageText) continue;
+
+    if (message.bot_id && (!botUserId || message.bot_id === botUserId)) {
+      const completeToolCallInfo = getCompleteToolCallInfoFromMessage(message);
+      if (completeToolCallInfo) {
+        summaryLines.push(`  (Assistant used tool(s): ${completeToolCallInfo}.`);
+        // Ignore the message text when there are tool calls - it's procedurally generated and not helpful to the assistant
+      } else {
+        summaryLines.push(`Assistant: ${trimmedMessageText}`);
+      }
+    } else if (message.user) {
+      summaryLines.push(`User <@${message.user}>: ${trimmedMessageText}`);
+    }
+  }
+
+  if (summaryLines.length === 0) {
+    return 'No relevant conversation history to summarize.';
+  }
+
+  return summaryLines.join('\n');
 };
 
 /**
  * Pack tool call info into Slack message metadata.
- * This metadata will later be unpacked by {@link unpackToolCallSlackMessage}.
+ * This metadata is used to record tool calls made by the assistant.
  * @param toolCalls - The LLM tool call info to pack.
  * @returns The Slack message metadata.
  */
@@ -74,43 +76,3 @@ export const packToolCallInfoIntoSlackMessageMetadata = (
     tool_calls: JSON.stringify(toolCalls),
   },
 });
-
-/**
- * Convert a Slack message into a list of LLM chat messages.
- * Prepends user messages with their Slack ID for multi-user context.
- * When Slack messages contain tool call metadata, they may result in multiple LLM chat messages.
- *
- * @param slackMessage - The Slack message to convert.
- * @returns The LLM chat messages.
- */
-export function convertSlackMessageToLLMMessages(message: MessageElement): ChatMessage[] {
-  if (!message.text) {
-    return [];
-  }
-
-  if (message.bot_id) {
-    const messages: ChatMessage[] = [{ role: 'assistant', content: message.text }];
-    if (message.metadata?.event_type === 'llm_tool_calls') {
-      const toolCallMessages = unpackToolCallSlackMessage(message);
-      messages.push(...toolCallMessages);
-    }
-    return messages;
-  }
-  // User message: Prepend content with user ID
-  return [{ role: 'user', content: `<@${message.user}>: ${message.text}` }];
-}
-
-/**
- * Convert Slack message history into a format suitable for using as LLM chat history.
- * @param slackHistory - The Slack message history to convert.
- * @param userSlackMessageTs - The timestamp of the user's message.
- * @returns The LLM chat history.
- */
-export function convertSlackHistoryToLLMHistory(
-  messages: MessageElement[],
-  triggeringMessageTs?: string,
-): ChatMessage[] {
-  return messages
-    .filter((message) => message.text && message.ts !== triggeringMessageTs)
-    .flatMap(convertSlackMessageToLLMMessages);
-}

--- a/src/assistant/prompts.ts
+++ b/src/assistant/prompts.ts
@@ -36,7 +36,8 @@ When formatting your responses, respond purely in Slack message syntax, don't su
 
 2. When mentioning members:
    - IF you have a user's Slack ID, use the format "<${NINEZERO_SLACK_MEMBER_LINK_PREFIX}member_id|member_name>" when referencing the member. For instance, if the member ID is U073CUASRSR and their name is Lowell Bander, you should use "<${NINEZERO_SLACK_MEMBER_LINK_PREFIX}U073CUASRSR|Lowell Bander>". When you do so, do you do not need to separately mention the member's name.
-   - The first time you mention each user, if you have both the linkedin profile url and the slack id, use this exact format: "<${NINEZERO_SLACK_MEMBER_LINK_PREFIX}U073CUASRSR|Lowell Bander> (<https://www.linkedin.com/in/the_user|Linkedin>)".
+   - If you don't have a user's name, use the phrase "this member" or a similar placeholder like "<${NINEZERO_SLACK_MEMBER_LINK_PREFIX}member_id|this member>". Alternately, if the person features prominently and would likely desire to be notified that they were mentioned, you can @mention them with the format <@member_id>.
+   - The first time you mention each user, if you have both the linkedin profile url and the slack id, use this exact format: "<${NINEZERO_SLACK_MEMBER_LINK_PREFIX}U073CUASRSR|member_name> (<https://www.linkedin.com/in/the_user|Linkedin>)".
    - If you have the member's linkedin profile url but not their slack ID, use this format to mention them: "Member Name (<https://www.linkedin.com/in/the_user|Linkedin>)".
    - Never URLencode or escape the <URL|text> format. Use literal < and > characters.
    - Once you have mentioned the user once with their Slack ID and linkedin URL (as available), use judgement for whether to refer to them subsequently by their name or Slack ID and whether to repeat the linkedin link.

--- a/src/assistant/slackInteraction.ts
+++ b/src/assistant/slackInteraction.ts
@@ -149,12 +149,15 @@ const getAuthInfo = async (client: WebClient): Promise<AuthTestResponse> => {
   return authTestResponse;
 };
 
-export const getBotId = async (client: WebClient): Promise<string> => {
-  const authInfo = await getAuthInfo(client);
-  return authInfo.bot_id as string;
+export type BotIds = {
+  botId: string;
+  userId: string;
 };
 
-export const getBotUserId = async (client: WebClient): Promise<string> => {
+export const getBotIds = async (client: WebClient): Promise<BotIds> => {
   const authInfo = await getAuthInfo(client);
-  return authInfo.user_id as string;
+  return {
+    botId: authInfo.bot_id as string,
+    userId: authInfo.user_id as string,
+  };
 };

--- a/src/assistant/slackInteraction.ts
+++ b/src/assistant/slackInteraction.ts
@@ -149,6 +149,12 @@ const getAuthInfo = async (client: WebClient): Promise<AuthTestResponse> => {
   return authTestResponse;
 };
 
+/* Slack bots get two IDs: bot ID and user ID. Why both? I'm not sure.
+ *
+ * In the context of Slack messages, the user ID is used in place of a normal user ID while the bot ID goes in the bot_id field.
+ * Messages from a bot look like { user: 'U123', bot_id: 'B123', ... }
+ * Messages from a user look similar but with no bot_id field.
+ */
 export type BotIds = {
   botId: string;
   userId: string;

--- a/src/services/mocks.ts
+++ b/src/services/mocks.ts
@@ -52,7 +52,7 @@ export const mockSlackService = {
 };
 
 export const mockSlackInteractionService = {
-  getBotUserId: jest.fn(),
+  getBotIds: jest.fn(),
 };
 
 export const mockLoggerService = {


### PR DESCRIPTION
revamp how we are handling the Slack thread history for the LLM.

# Improved behaviors

* assistant doesn't repeat the automated tool call messages anymore
* assistant doesn't get obsessed with previous questions
* assistant is less likely to hallucinate based on previous behavior
* assistant should no longer see its previous messages as training data, and should be less confused if a prompt changes and its previous behavior conflicts with the new prompt
* there may have also been a bug in how Fabric decided whether to respond in threads as well.. I cleaned up getBotId()